### PR TITLE
security: API auth, loopback bind, CORS hardening (#34)

### DIFF
--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -153,7 +153,7 @@ engine.unlock()  # Decrypt memory pack
 ### Security
 
 - Set `PRME_ENCRYPTION_ENABLED=true` for data at rest
-- The HTTP API enables CORS `*` by default — restrict `allow_origins` in production
+- The HTTP API binds to `127.0.0.1` and disables CORS by default; set `PRME_API_API_KEY` before exposing it on `0.0.0.0`, and pin `PRME_API_CORS_ORIGINS` if browser clients need access
 - The MCP server runs over stdio (no network exposure) by default
 - Never commit `.env` files with API keys to version control
 
@@ -173,6 +173,8 @@ ENV PRME_LEXICAL_PATH=/data/lexical_index
 VOLUME /data
 EXPOSE 8000
 
+# 0.0.0.0 is required inside the container; pass PRME_API_API_KEY at
+# `docker run` time so the exposed port requires authentication.
 CMD ["uvicorn", "prme.api:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 

--- a/documentation/http-api.md
+++ b/documentation/http-api.md
@@ -17,10 +17,28 @@ uvicorn prme.api:app
 Or with custom host/port:
 
 ```bash
-uvicorn prme.api:app --host 0.0.0.0 --port 8000
+uvicorn prme.api:app --host 127.0.0.1 --port 8000
 ```
 
+The server binds to `127.0.0.1` (loopback only) by default. Binding to `0.0.0.0` exposes the API to the network and is an explicit opt-in — set an API key first (see [Authentication](#authentication)) or put the server behind an authenticating reverse proxy. `python -m prme.api` logs a warning when binding to a non-loopback address.
+
 The API reads configuration from environment variables (`PRME_*` prefix). Set `PRME_DB_PATH`, `PRME_VECTOR_PATH`, and `PRME_LEXICAL_PATH` to point at your memory directory.
+
+## Authentication
+
+Authentication is disabled by default (suitable for single-user localhost use). To require bearer-token auth on all endpoints except `/v1/health`:
+
+```bash
+export PRME_API_API_KEY="your-secret-key"
+```
+
+Clients must then send:
+
+```
+Authorization: Bearer your-secret-key
+```
+
+Requests with a missing or wrong key receive `401 {"detail": "Invalid or missing API key"}`.
 
 ## Endpoints
 
@@ -269,7 +287,11 @@ Health check.
 
 ### GET /v1/stats
 
-System statistics.
+System statistics. Node counting uses `COUNT(*)` (no rows are materialized).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `user_id` | string | | Scope the node count to one user |
 
 **Response (200):**
 
@@ -284,7 +306,14 @@ System statistics.
 
 ## CORS
 
-CORS is enabled by default with `allow_origins=["*"]`. Suitable for development; restrict origins in production.
+CORS is disabled by default — browser pages cannot read API responses cross-origin. To allow specific origins:
+
+```bash
+export PRME_API_CORS_ORIGINS='["http://localhost:3000"]'
+export PRME_API_CORS_ALLOW_CREDENTIALS=true   # optional
+```
+
+Credentialed CORS is only honored when origins are explicitly pinned; a wildcard (`*`) origin never allows credentials.
 
 ## Error Responses
 
@@ -298,6 +327,8 @@ All errors follow this format:
 
 | Status | Meaning |
 |--------|---------|
+| 401 | Missing or invalid API key (when auth is enabled) |
 | 404 | Node/resource not found |
 | 422 | Invalid input (bad enum value, invalid state transition) |
+| 500 | Unexpected internal error (details logged server-side only) |
 | 503 | Engine not initialized |

--- a/memory_bank/reviews/issue-34-api-auth-bind-cors-hardening-review.md
+++ b/memory_bank/reviews/issue-34-api-auth-bind-cors-hardening-review.md
@@ -1,0 +1,97 @@
+# Review — issue-34-api-auth-bind-cors-hardening
+
+Six-agent code review of the security hardening for issue #34 (REST API auth,
+bind default, CORS, error sanitization, stats COUNT). Base branch: `main`.
+
+## Files Changed
+
+- `src/prme/config.py` — new `APIConfig` (api_key, cors_origins, cors_allow_credentials) nested as `PRMEConfig.api`
+- `src/prme/api/routes.py` — `require_api_key` bearer dependency on the router; `/v1/health` on `public_router`; `/v1/stats` uses `count_nodes()` with optional `user_id` scoping
+- `src/prme/api/app.py` — CORS only when origins pinned, credentials never with wildcard; generic 500 handler; config on `app.state`
+- `src/prme/api/server.py`, `src/prme/api/__main__.py` — default bind `127.0.0.1`; warning on non-loopback bind
+- `src/prme/storage/graph_store.py`, `duckpgq_graph.py`, `pg/graph_store.py`, `engine.py` — `count_nodes()` (`SELECT COUNT(*)`)
+- `src/prme/types.py` — shared `ACTIVE_LIFECYCLE_STATES` constant (review follow-up)
+- `src/prme/mcp/server.py` — `_internal_error()` for unexpected exceptions; `memory://stats` uses `count_nodes()`; FastMCP `description=` → `instructions=` (mcp 1.26 API; pre-existing import-time breakage)
+- `documentation/http-api.md`, `documentation/deployment.md` — auth/CORS/bind docs
+- `tests/test_api.py` — auth, CORS, stats-scoping tests
+
+## Approach Summary
+
+All five issue #34 checkboxes implemented as small mechanical changes at the
+network boundary. Auth is config-driven and a no-op when `PRME_API_API_KEY`
+is unset, preserving the local-first single-user workflow. Controlled
+`ValueError` validation messages (lifecycle transitions) are still surfaced;
+only unexpected exceptions are made generic and logged server-side.
+
+## Must Fix
+
+| # | Finding | Source | Status |
+|---|---------|--------|--------|
+| 1 | `graph_store.py` `query_nodes` docstring said default is `[TENTATIVE, STABLE]` but implementations use TENTATIVE/STABLE/CONTESTED | Agent 4 | Resolved — docstring corrected |
+
+## Should Fix
+
+| # | Finding | Source | Status |
+|---|---------|--------|--------|
+| 2 | Active lifecycle-state default list duplicated across 4 backend methods | Agents 4, 5 | Resolved — extracted `ACTIVE_LIFECYCLE_STATES` to `prme/types.py`, used in all 4 sites |
+| 3 | `api_key` should be `SecretStr` | Agent 2 | Deferred — matches existing plain-`str` secret pattern (`embedding.api_key`, `encryption_key`); converting all secrets is audit finding LOW-1, its own follow-up |
+| 4 | FastMCP kwarg rename undocumented | Agent 3 | Resolved — comment added at the call site |
+
+## Consider (noted, intentionally not changed)
+
+- `app.state.engine = None` at create time (Agent 5): kept — makes `_get_engine` return a clean 503 instead of `AttributeError` before lifespan runs.
+- `/v1/stats` behind auth (Agent 5): kept — node counts are user data; `/v1/health` is the unauthenticated probe.
+- Refuse startup on non-loopback bind without key (Agent 2): warning chosen per issue wording ("explicit opt-in and a warning").
+- IPv4-mapped IPv6 loopback forms not in `_LOOPBACK_HOSTS` (Agent 1): acceptable; warning is best-effort.
+- CORS credentials warning "unreachable" (Agent 1): incorrect — it fires when `cors_allow_credentials=True` and `*` is in origins.
+
+## Out of Scope (pre-existing, not regressions from this change)
+
+- PG `_UPDATE_ALLOWED_FIELDS` missing `ttl_days`/`event_time` vs DuckDB (Agent 1)
+- `event_count` hardcoded to 0 in `/v1/stats` (Agents 1, 3)
+- Node-to-dict conversion duplicated between API and MCP layers (Agents 3, 4)
+- Tenant isolation / server-side identity binding (audit HIGH-3, tracked separately)
+
+## Security Audit Results (Agent 2)
+
+| Area | Result | Details |
+|------|--------|---------|
+| Timing-safe key comparison | PASS | `secrets.compare_digest`, routes.py |
+| Auth applied to every protected route | PASS | router-level dependency; only `/v1/health` public |
+| Auth bypass vectors (query string, case) | PASS | HTTPBearer header-only, case-insensitive scheme per RFC 7235 |
+| SQL parameterization in `count_nodes` | PASS | `?` / `$N` placeholders both backends |
+| Error responses echo internals | PASS | generic 500 handler + MCP `_internal_error`; ValueError messages are curated validation text |
+| CORS default off, wildcard+credentials blocked | PASS | middleware only added when origins pinned |
+| Secrets in logs | PASS | warnings never include the key |
+| Bind default | PASS | `127.0.0.1` both entry points |
+
+## Pattern Consistency Assessment (Agent 4)
+
+`APIConfig` matches the nested-settings pattern (env_prefix, Field defaults,
+registration in `PRMEConfig`). `count_nodes` matches `query_nodes` across
+protocol, both backends, and the engine facade. DRY finding on lifecycle
+states resolved via shared constant.
+
+## Redundancy Check (Agent 5)
+
+No redundant abstractions or dependencies added; all new imports stdlib or
+already-used FastAPI modules. Per-layer error helpers justified (different
+return types).
+
+## Wiring Findings (Agent 6)
+
+Both routers registered; all 13 endpoints reachable (12 protected + health);
+`PRME_API_API_KEY` and nested `PRME_API__API_KEY` env forms both verified
+working; both GraphStore implementations satisfy the updated protocol; no
+other implementations exist; CI discovers tests wholesale. Full suite: 930
+passed, 25 skipped at review time.
+
+## Resolution Status
+
+| Finding | Severity | Status |
+|---------|----------|--------|
+| query_nodes docstring default | Must Fix | Resolved |
+| Lifecycle-states duplication | Should Fix | Resolved |
+| SecretStr for api_key | Should Fix | Deferred (audit LOW-1 follow-up) |
+| FastMCP kwarg comment | Should Fix | Resolved |
+| Auth/CORS/stats test coverage | Consider | Resolved (tests added in testing phase) |

--- a/src/prme/api/__main__.py
+++ b/src/prme/api/__main__.py
@@ -16,7 +16,12 @@ def main() -> None:
         prog="python -m prme.api",
     )
     parser.add_argument(
-        "--host", default="0.0.0.0", help="Bind address (default: 0.0.0.0)"
+        "--host",
+        default="127.0.0.1",
+        help=(
+            "Bind address (default: 127.0.0.1). Use 0.0.0.0 only with an "
+            "API key (PRME_API_API_KEY) or behind an authenticating proxy."
+        ),
     )
     parser.add_argument(
         "--port", type=int, default=8000, help="Port (default: 8000)"

--- a/src/prme/api/app.py
+++ b/src/prme/api/app.py
@@ -11,8 +11,9 @@ import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from prme.config import PRMEConfig
 
@@ -55,18 +56,50 @@ def create_app(config: PRMEConfig | None = None) -> FastAPI:
         lifespan=lifespan,
     )
 
-    # CORS middleware — enabled by default for broad compatibility
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # Expose config to request handlers (auth dependency reads it).
+    app.state.config = config
+    app.state.engine = None
+
+    # CORS — disabled unless origins are explicitly pinned (issue #34).
+    # Credentials are never allowed with a wildcard origin: Starlette
+    # reflects the request Origin in that combination, letting any
+    # website read responses cross-origin.
+    cors_origins = config.api.cors_origins
+    if cors_origins:
+        allow_credentials = (
+            config.api.cors_allow_credentials and "*" not in cors_origins
+        )
+        if config.api.cors_allow_credentials and not allow_credentials:
+            logger.warning(
+                "cors_allow_credentials ignored: wildcard origin in "
+                "cors_origins. Pin explicit origins to allow credentials."
+            )
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=allow_credentials,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    # Generic handler for unexpected errors: log details server-side,
+    # never echo internals to the caller (issue #34).
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(
+        request: Request, exc: Exception
+    ) -> JSONResponse:
+        logger.error(
+            "Unhandled error on %s %s", request.method, request.url.path,
+            exc_info=exc,
+        )
+        return JSONResponse(
+            status_code=500, content={"detail": "Internal server error"}
+        )
 
     # Register routes
-    from prme.api.routes import router
+    from prme.api.routes import public_router, router
 
+    app.include_router(public_router)
     app.include_router(router)
 
     return app

--- a/src/prme/api/routes.py
+++ b/src/prme/api/routes.py
@@ -7,9 +7,11 @@ No business logic belongs here — delegate everything to the engine.
 from __future__ import annotations
 
 import logging
+import secrets
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from prme.api.models import (
     ErrorResponse,
@@ -31,7 +33,45 @@ from prme.types import LifecycleState, NodeType, Scope
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/v1")
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def require_api_key(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> None:
+    """Require a valid bearer token when an API key is configured.
+
+    When ``config.api.api_key`` is None (the default), authentication is
+    disabled and all requests pass — appropriate for single-user
+    localhost deployments. When set, every protected route requires
+    ``Authorization: Bearer <api_key>``.
+    """
+    config = getattr(request.app.state, "config", None)
+    api_key = config.api.api_key if config is not None else None
+    if api_key is None:
+        return
+    if credentials is None or not secrets.compare_digest(
+        credentials.credentials, api_key
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+# Protected router: all memory operations require authentication when
+# an API key is configured.
+router = APIRouter(prefix="/v1", dependencies=[Depends(require_api_key)])
+
+# Public router: liveness/health checks only — never requires auth.
+public_router = APIRouter(prefix="/v1")
 
 
 # ---------------------------------------------------------------------------
@@ -433,7 +473,7 @@ async def get_chain(
 # ---------------------------------------------------------------------------
 
 
-@router.get(
+@public_router.get(
     "/health",
     response_model=HealthResponse,
     summary="Health check",
@@ -448,8 +488,8 @@ async def health(request: Request) -> HealthResponse:
     response_model=StatsResponse,
     summary="System statistics",
 )
-async def stats(request: Request) -> StatsResponse:
-    """Get system statistics."""
+async def stats(request: Request, user_id: str | None = None) -> StatsResponse:
+    """Get system statistics, optionally scoped to a single user."""
     engine = _get_engine(request)
 
     node_count = 0
@@ -458,9 +498,7 @@ async def stats(request: Request) -> StatsResponse:
     details: dict[str, Any] = {}
 
     try:
-        # Count nodes via query_nodes with high limit
-        nodes = await engine.query_nodes(limit=10000)
-        node_count = len(nodes)
+        node_count = await engine.count_nodes(user_id=user_id)
     except Exception:
         logger.warning("Failed to count nodes for stats", exc_info=True)
 

--- a/src/prme/api/server.py
+++ b/src/prme/api/server.py
@@ -13,8 +13,11 @@ from prme.config import PRMEConfig
 logger = logging.getLogger(__name__)
 
 
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
 def run_server(
-    host: str = "0.0.0.0",
+    host: str = "127.0.0.1",
     port: int = 8000,
     config: PRMEConfig | None = None,
     log_level: str = "info",
@@ -22,7 +25,11 @@ def run_server(
     """Start the PRME HTTP API server.
 
     Args:
-        host: Bind address. Defaults to "0.0.0.0".
+        host: Bind address. Defaults to "127.0.0.1" (loopback only).
+            Binding to a non-loopback address (e.g. "0.0.0.0") exposes
+            the API to the network and requires explicit opt-in; set
+            an API key (PRME_API_API_KEY) or front it with an
+            authenticating reverse proxy first.
         port: Port number. Defaults to 8000.
         config: Optional PRME configuration.
         log_level: Uvicorn log level. Defaults to "info".
@@ -30,6 +37,24 @@ def run_server(
     import uvicorn
 
     from prme.api.app import create_app
+
+    if config is None:
+        config = PRMEConfig()
+
+    if host not in _LOOPBACK_HOSTS:
+        if config.api.api_key is None:
+            logger.warning(
+                "Binding to %s with NO API key configured: anyone on the "
+                "network can read, write, and archive memories. Set "
+                "PRME_API_API_KEY or bind to 127.0.0.1.",
+                host,
+            )
+        else:
+            logger.warning(
+                "Binding to non-loopback address %s — API is exposed to "
+                "the network (bearer-token auth is enabled).",
+                host,
+            )
 
     app = create_app(config)
     uvicorn.run(app, host=host, port=port, log_level=log_level)

--- a/src/prme/config.py
+++ b/src/prme/config.py
@@ -63,6 +63,40 @@ class EmbeddingConfig(BaseSettings):
     }
 
 
+class APIConfig(BaseSettings):
+    """Configuration for the HTTP API server (security hardening, issue #34)."""
+
+    api_key: str | None = Field(
+        default=None,
+        description=(
+            "API key for bearer-token authentication. When set, every "
+            "endpoint except /v1/health requires "
+            "'Authorization: Bearer <api_key>'. None (default) disables "
+            "authentication — only safe for single-user localhost use."
+        ),
+    )
+    cors_origins: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Allowed CORS origins. Empty (default) disables CORS entirely. "
+            "Pin explicit origins (e.g. ['http://localhost:3000']) for "
+            "browser clients. Avoid '*' — credentials are never allowed "
+            "with a wildcard origin."
+        ),
+    )
+    cors_allow_credentials: bool = Field(
+        default=False,
+        description=(
+            "Allow credentialed CORS requests. Only honored when "
+            "cors_origins pins explicit origins (no '*')."
+        ),
+    )
+
+    model_config = {
+        "env_prefix": "PRME_API_",
+    }
+
+
 class OrganizerConfig(BaseSettings):
     """Configuration for self-organizing memory (RFC-0015)."""
 
@@ -238,6 +272,10 @@ class PRMEConfig(BaseSettings):
     organizer: OrganizerConfig = Field(
         default_factory=OrganizerConfig,
         description="Self-organizing memory configuration (RFC-0015)",
+    )
+    api: APIConfig = Field(
+        default_factory=APIConfig,
+        description="HTTP API server configuration (auth, CORS)",
     )
     enable_store_supersedence: bool = Field(
         default=False,

--- a/src/prme/mcp/server.py
+++ b/src/prme/mcp/server.py
@@ -55,6 +55,17 @@ def _get_engine(ctx: Context) -> Any:
     return ctx.request_context.lifespan_context["engine"]
 
 
+def _internal_error(operation: str, exc: Exception) -> str:
+    """Log an unexpected error server-side and return a generic payload.
+
+    Raw exception strings can leak internal paths, SQL fragments, or
+    library internals to remote callers (issue #34) — details go to the
+    server log only.
+    """
+    logger.error("Unexpected error in %s", operation, exc_info=exc)
+    return json.dumps({"error": f"Internal error in {operation}"})
+
+
 # ---------------------------------------------------------------------------
 # Lifespan
 # ---------------------------------------------------------------------------
@@ -85,9 +96,10 @@ async def engine_lifespan(server: FastMCP):
 # Server
 # ---------------------------------------------------------------------------
 
+# Note: mcp>=1.x FastMCP takes "instructions" (formerly "description").
 mcp = FastMCP(
     "prme",
-    description="PRME — Portable Relational Memory Engine. "
+    instructions="PRME — Portable Relational Memory Engine. "
     "Store, retrieve, and organize long-term memory for AI agents.",
     lifespan=engine_lifespan,
 )
@@ -153,7 +165,7 @@ async def memory_store(
 
         return json.dumps({"event_id": event_id, "node_id": node_id})
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory_store", e)
 
 
 @mcp.tool()
@@ -216,7 +228,7 @@ async def memory_retrieve(
             "count": len(results),
         })
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory_retrieve", e)
 
 
 @mcp.tool()
@@ -255,7 +267,7 @@ async def memory_ingest(
         )
         return json.dumps({"event_id": event_id})
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory_ingest", e)
 
 
 @mcp.tool()
@@ -292,7 +304,7 @@ async def memory_organize(
             "duration_ms": result.duration_ms,
         })
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory_organize", e)
 
 
 @mcp.tool()
@@ -316,7 +328,7 @@ async def memory_get_node(
             return json.dumps({"error": f"Node {node_id!r} not found"})
         return json.dumps(_node_to_dict(node))
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory_get_node", e)
 
 
 @mcp.tool()
@@ -346,9 +358,10 @@ async def memory_promote_node(
             return json.dumps({"error": f"Node {node_id!r} not found after promote"})
         return json.dumps(_node_to_dict(updated))
     except ValueError as e:
+        # Controlled validation message (e.g. invalid lifecycle transition).
         return json.dumps({"error": str(e)})
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory_promote_node", e)
 
 
 @mcp.tool()
@@ -378,9 +391,10 @@ async def memory_archive_node(
             return json.dumps({"error": f"Node {node_id!r} not found after archive"})
         return json.dumps(_node_to_dict(updated))
     except ValueError as e:
+        # Controlled validation message (e.g. invalid lifecycle transition).
         return json.dumps({"error": str(e)})
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory_archive_node", e)
 
 
 # ---------------------------------------------------------------------------
@@ -404,10 +418,9 @@ async def resource_stats() -> str:
     node_count = 0
     backend = "duckdb"
     try:
-        nodes = await engine.query_nodes(limit=10000)
-        node_count = len(nodes)
+        node_count = await engine.count_nodes()
     except Exception:
-        pass
+        logger.warning("Failed to count nodes for stats", exc_info=True)
 
     try:
         backend = engine._config.backend
@@ -434,7 +447,7 @@ async def resource_node(node_id: str) -> str:
             return json.dumps({"error": f"Node {node_id!r} not found"})
         return json.dumps(_node_to_dict(node))
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        return _internal_error("memory://nodes resource", e)
 
 
 # ---------------------------------------------------------------------------

--- a/src/prme/storage/duckpgq_graph.py
+++ b/src/prme/storage/duckpgq_graph.py
@@ -21,6 +21,7 @@ import duckdb
 from prme.models.edges import MemoryEdge
 from prme.models.nodes import MemoryNode
 from prme.types import (
+    ACTIVE_LIFECYCLE_STATES,
     ALLOWED_TRANSITIONS,
     DecayProfile,
     EdgeType,
@@ -124,6 +125,29 @@ class DuckPGQGraphStore:
                 valid_at,
                 min_confidence,
                 limit,
+            )
+
+    async def count_nodes(
+        self,
+        *,
+        user_id: str | None = None,
+        lifecycle_states: list[LifecycleState] | None = None,
+    ) -> int:
+        """Count nodes matching the filters via SELECT COUNT(*).
+
+        Defaults to counting active states (tentative + stable +
+        contested), matching query_nodes().
+
+        Args:
+            user_id: Filter by user.
+            lifecycle_states: Lifecycle filter (defaults to active).
+
+        Returns:
+            Number of matching nodes.
+        """
+        async with self._conn_lock:
+            return await asyncio.to_thread(
+                self._count_nodes_sync, user_id, lifecycle_states
             )
 
     # --- Node Update ---
@@ -619,11 +643,7 @@ class DuckPGQGraphStore:
         # per Research Pitfall 3 -- contested nodes are active with unresolved
         # conflicts but still valid candidates for retrieval).
         if lifecycle_states is None:
-            lifecycle_states = [
-                LifecycleState.TENTATIVE,
-                LifecycleState.STABLE,
-                LifecycleState.CONTESTED,
-            ]
+            lifecycle_states = list(ACTIVE_LIFECYCLE_STATES)
 
         # Build lifecycle IN clause
         placeholders = ", ".join(["?" for _ in lifecycle_states])
@@ -663,6 +683,33 @@ class DuckPGQGraphStore:
 
         rows = self._conn.execute(query, params).fetchall()
         return [self._row_to_node(row) for row in rows]
+
+    def _count_nodes_sync(
+        self,
+        user_id: str | None,
+        lifecycle_states: list[LifecycleState] | None,
+    ) -> int:
+        """Count nodes with SELECT COUNT(*) (sync)."""
+        conditions: list[str] = []
+        params: list = []
+
+        # Same default lifecycle filter as _query_nodes_sync.
+        if lifecycle_states is None:
+            lifecycle_states = list(ACTIVE_LIFECYCLE_STATES)
+
+        placeholders = ", ".join(["?" for _ in lifecycle_states])
+        conditions.append(f"lifecycle_state IN ({placeholders})")
+        params.extend([s.value for s in lifecycle_states])
+
+        if user_id is not None:
+            conditions.append("user_id = ?")
+            params.append(user_id)
+
+        where_clause = " AND ".join(conditions)
+        query = f"SELECT COUNT(*) FROM nodes WHERE {where_clause}"
+
+        row = self._conn.execute(query, params).fetchone()
+        return int(row[0]) if row else 0
 
     def _create_edge_sync(self, edge: MemoryEdge) -> None:
         """Insert an edge into the edges table (sync)."""

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -1360,6 +1360,18 @@ class MemoryEngine:
         """
         return await self._graph_store.query_nodes(**kwargs)
 
+    async def count_nodes(self, **kwargs) -> int:
+        """Count nodes matching the filters without materializing them.
+
+        Defaults to active lifecycle states (tentative + stable + contested).
+        Accepts the keyword arguments supported by GraphStore.count_nodes()
+        (user_id, lifecycle_states).
+
+        Returns:
+            Number of matching nodes.
+        """
+        return await self._graph_store.count_nodes(**kwargs)
+
     # --- Event Operations (delegated to EventStore) ---
 
     async def get_event(self, event_id: str) -> Event | None:

--- a/src/prme/storage/graph_store.py
+++ b/src/prme/storage/graph_store.py
@@ -78,13 +78,32 @@ class GraphStore(Protocol):
             user_id: Filter by owner user.
             scope: Filter by memory scope.
             lifecycle_states: Filter by lifecycle states. Defaults to
-                [TENTATIVE, STABLE] (active only).
+                active states (TENTATIVE, STABLE, CONTESTED).
             valid_at: Temporal filter -- return nodes valid at this time.
             min_confidence: Minimum confidence threshold.
             limit: Maximum results to return.
 
         Returns:
             List of matching MemoryNodes.
+        """
+        ...
+
+    async def count_nodes(
+        self,
+        *,
+        user_id: str | None = None,
+        lifecycle_states: list[LifecycleState] | None = None,
+    ) -> int:
+        """Count nodes matching the filters without materializing them.
+
+        Args:
+            user_id: Filter by owner user.
+            lifecycle_states: Filter by lifecycle states. Defaults to
+                active states (TENTATIVE, STABLE, CONTESTED), matching
+                query_nodes().
+
+        Returns:
+            Number of matching nodes.
         """
         ...
 

--- a/src/prme/storage/pg/graph_store.py
+++ b/src/prme/storage/pg/graph_store.py
@@ -18,6 +18,7 @@ import asyncpg
 from prme.models.edges import MemoryEdge
 from prme.models.nodes import MemoryNode
 from prme.types import (
+    ACTIVE_LIFECYCLE_STATES,
     DecayProfile,
     EdgeType,
     EpistemicType,
@@ -152,11 +153,7 @@ class PgGraphStore:
         idx = 1
 
         if lifecycle_states is None:
-            lifecycle_states = [
-                LifecycleState.TENTATIVE,
-                LifecycleState.STABLE,
-                LifecycleState.CONTESTED,
-            ]
+            lifecycle_states = list(ACTIVE_LIFECYCLE_STATES)
 
         placeholders = ", ".join(f"${idx + i}" for i in range(len(lifecycle_states)))
         conditions.append(f"lifecycle_state IN ({placeholders})")
@@ -202,6 +199,41 @@ class PgGraphStore:
         async with self._pool.acquire() as conn:
             rows = await conn.fetch(query, *params)
         return [self._record_to_node(row) for row in rows]
+
+    async def count_nodes(
+        self,
+        *,
+        user_id: str | None = None,
+        lifecycle_states: list[LifecycleState] | None = None,
+    ) -> int:
+        """Count nodes matching the filters via SELECT COUNT(*).
+
+        Defaults to counting active states (tentative + stable +
+        contested), matching query_nodes().
+        """
+        conditions: list[str] = []
+        params: list = []
+        idx = 1
+
+        if lifecycle_states is None:
+            lifecycle_states = list(ACTIVE_LIFECYCLE_STATES)
+
+        placeholders = ", ".join(f"${idx + i}" for i in range(len(lifecycle_states)))
+        conditions.append(f"lifecycle_state IN ({placeholders})")
+        params.extend(s.value for s in lifecycle_states)
+        idx += len(lifecycle_states)
+
+        if user_id is not None:
+            conditions.append(f"user_id = ${idx}")
+            params.append(user_id)
+            idx += 1
+
+        where = " AND ".join(conditions)
+        query = f"SELECT COUNT(*) FROM nodes WHERE {where}"
+
+        async with self._pool.acquire() as conn:
+            count = await conn.fetchval(query, *params)
+        return int(count or 0)
 
     # --- Node Update ---
 

--- a/src/prme/types.py
+++ b/src/prme/types.py
@@ -242,6 +242,15 @@ DEFAULT_EXCLUDED_EPISTEMIC: set[EpistemicType] = {
     EpistemicType.DEPRECATED,
 }
 
+# Active lifecycle states — the default filter for node queries and counts.
+# CONTESTED is included: contested nodes have unresolved conflicts but are
+# still valid retrieval candidates (RFC-0003).
+ACTIVE_LIFECYCLE_STATES: tuple[LifecycleState, ...] = (
+    LifecycleState.TENTATIVE,
+    LifecycleState.STABLE,
+    LifecycleState.CONTESTED,
+)
+
 
 def validate_transition(current: LifecycleState, target: LifecycleState) -> bool:
     """Check whether a lifecycle state transition is valid.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ import pytest_asyncio
 from fastapi.testclient import TestClient
 
 from prme.api.app import create_app
-from prme.config import PRMEConfig
+from prme.config import APIConfig, PRMEConfig
 from prme.storage.engine import MemoryEngine
 
 
@@ -420,3 +420,204 @@ class TestErrorHandling:
     def test_nonexistent_endpoint_returns_404(self, client):
         resp = client.get("/v1/nonexistent")
         assert resp.status_code in (404, 405)
+
+
+# ---------------------------------------------------------------------------
+# Authentication (issue #34)
+# ---------------------------------------------------------------------------
+
+TEST_API_KEY = "test-secret-key"
+
+
+@pytest.fixture
+def auth_config(tmp_dir):
+    """Config with bearer-token auth enabled."""
+    lexical_path = Path(tmp_dir) / "lexical_index"
+    lexical_path.mkdir(exist_ok=True)
+    return PRMEConfig(
+        db_path=str(Path(tmp_dir) / "memory.duckdb"),
+        vector_path=str(Path(tmp_dir) / "vectors.usearch"),
+        lexical_path=str(lexical_path),
+        api=APIConfig(api_key=TEST_API_KEY),
+    )
+
+
+@pytest.fixture
+def auth_client(auth_config):
+    """TestClient against an app that requires an API key."""
+    with TestClient(create_app(auth_config), raise_server_exceptions=True) as c:
+        yield c
+
+
+class TestAuth:
+    def test_missing_token_returns_401(self, auth_client):
+        resp = auth_client.get("/v1/nodes")
+        assert resp.status_code == 401
+        assert resp.headers.get("WWW-Authenticate") == "Bearer"
+
+    def test_wrong_token_returns_401(self, auth_client):
+        resp = auth_client.get(
+            "/v1/nodes",
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert resp.status_code == 401
+
+    def test_valid_token_succeeds(self, auth_client):
+        resp = auth_client.get(
+            "/v1/nodes",
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+        assert resp.status_code == 200
+
+    def test_post_route_requires_token(self, auth_client):
+        resp = auth_client.post(
+            "/v1/store",
+            json={"content": "secret fact", "user_id": "auth-user"},
+        )
+        assert resp.status_code == 401
+
+    def test_post_route_with_token_succeeds(self, auth_client):
+        resp = auth_client.post(
+            "/v1/store",
+            json={"content": "secret fact", "user_id": "auth-user"},
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+        assert resp.status_code == 200
+
+    def test_health_open_without_token(self, auth_client):
+        """Liveness checks must work without credentials."""
+        resp = auth_client.get("/v1/health")
+        assert resp.status_code == 200
+
+    def test_stats_requires_token(self, auth_client):
+        resp = auth_client.get("/v1/stats")
+        assert resp.status_code == 401
+
+    def test_no_api_key_configured_allows_access(self, client):
+        """Auth is a no-op when no API key is set (default client fixture)."""
+        resp = client.get("/v1/nodes")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CORS (issue #34)
+# ---------------------------------------------------------------------------
+
+
+class TestCORS:
+    def test_cors_disabled_by_default(self, client):
+        """No Access-Control-Allow-Origin header without pinned origins."""
+        resp = client.get(
+            "/v1/health",
+            headers={"Origin": "http://evil.example"},
+        )
+        assert resp.status_code == 200
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_cors_pinned_origin_allowed(self, tmp_dir):
+        lexical_path = Path(tmp_dir) / "lexical_index"
+        lexical_path.mkdir(exist_ok=True)
+        config = PRMEConfig(
+            db_path=str(Path(tmp_dir) / "memory.duckdb"),
+            vector_path=str(Path(tmp_dir) / "vectors.usearch"),
+            lexical_path=str(lexical_path),
+            api=APIConfig(
+                cors_origins=["http://localhost:3000"],
+                cors_allow_credentials=True,
+            ),
+        )
+        with TestClient(create_app(config)) as c:
+            resp = c.get(
+                "/v1/health",
+                headers={"Origin": "http://localhost:3000"},
+            )
+            assert (
+                resp.headers.get("access-control-allow-origin")
+                == "http://localhost:3000"
+            )
+            assert resp.headers.get("access-control-allow-credentials") == "true"
+
+            # Unpinned origins get no CORS headers.
+            resp = c.get(
+                "/v1/health",
+                headers={"Origin": "http://evil.example"},
+            )
+            assert "access-control-allow-origin" not in resp.headers
+
+    def test_cors_wildcard_never_allows_credentials(self, tmp_dir):
+        lexical_path = Path(tmp_dir) / "lexical_index"
+        lexical_path.mkdir(exist_ok=True)
+        config = PRMEConfig(
+            db_path=str(Path(tmp_dir) / "memory.duckdb"),
+            vector_path=str(Path(tmp_dir) / "vectors.usearch"),
+            lexical_path=str(lexical_path),
+            api=APIConfig(
+                cors_origins=["*"],
+                cors_allow_credentials=True,
+            ),
+        )
+        with TestClient(create_app(config)) as c:
+            resp = c.get(
+                "/v1/health",
+                headers={"Origin": "http://anywhere.example"},
+            )
+            assert "access-control-allow-credentials" not in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# Stats counting (issue #34)
+# ---------------------------------------------------------------------------
+
+
+class TestStatsCounting:
+    def test_stats_counts_stored_nodes(self, client):
+        client.post(
+            "/v1/store",
+            json={"content": "Fact one", "user_id": "stats-user-a"},
+        )
+        client.post(
+            "/v1/store",
+            json={"content": "Fact two", "user_id": "stats-user-b"},
+        )
+
+        resp = client.get("/v1/stats")
+        assert resp.status_code == 200
+        assert resp.json()["node_count"] >= 2
+
+    def test_stats_scoped_by_user(self, client):
+        client.post(
+            "/v1/store",
+            json={"content": "Scoped fact", "user_id": "stats-scoped-user"},
+        )
+        client.post(
+            "/v1/store",
+            json={"content": "Other user's fact", "user_id": "stats-other-user"},
+        )
+
+        scoped = client.get(
+            "/v1/stats", params={"user_id": "stats-scoped-user"}
+        ).json()
+        unscoped = client.get("/v1/stats").json()
+
+        assert scoped["node_count"] >= 1
+        assert unscoped["node_count"] > scoped["node_count"]
+
+    def test_stats_unknown_user_counts_zero(self, client):
+        resp = client.get("/v1/stats", params={"user_id": "nobody-here"})
+        assert resp.status_code == 200
+        assert resp.json()["node_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Server defaults (issue #34)
+# ---------------------------------------------------------------------------
+
+
+class TestServerDefaults:
+    def test_run_server_defaults_to_loopback(self):
+        import inspect
+
+        from prme.api.server import run_server
+
+        host_default = inspect.signature(run_server).parameters["host"].default
+        assert host_default == "127.0.0.1"


### PR DESCRIPTION
## Summary
- Default bind is now `127.0.0.1` (`run_server` and `python -m prme.api`); binding a non-loopback address is an explicit opt-in and logs a warning, louder when no API key is set
- New `APIConfig` adds config-driven bearer-token auth (`PRME_API_API_KEY`) on every `/v1` route except `/v1/health`, plus CORS controls — CORS is now off by default and credentials are never allowed with a wildcard origin
- Unexpected exceptions no longer echo raw `str(e)` to callers (generic 500 handler in the API, `_internal_error` in MCP tools; details logged server-side), and `/v1/stats` + MCP `memory://stats` count via a new `count_nodes()` (`SELECT COUNT(*)`, optional `user_id` scope) instead of materializing 10k nodes

Also fixes a pre-existing import-time `TypeError` in `prme.mcp.server`: mcp 1.26 renamed FastMCP's `description=` kwarg to `instructions=`, which had been erroring out the whole `tests/test_mcp.py` module.

Auth stays a no-op when no key is configured, so the local single-user workflow is unchanged. Review notes in `memory_bank/reviews/issue-34-api-auth-bind-cors-hardening-review.md` (SecretStr conversion deferred to the audit LOW-1 follow-up; tenant isolation is HIGH-3, tracked separately).

## Test plan
- [x] `uv run pytest -q` — 1060 passed, 25 skipped (PostgreSQL)
- [x] 15 new tests: 401 on missing/wrong token, 200 with token, `/v1/health` open without auth, no-op when no key set, CORS absent by default / pinned origin honored / wildcard never gets credentials, stats user scoping, loopback default
- [x] `ruff check` — no new findings in changed files vs `main`

## Verification steps
1. `uv run python -m prme.api` — server binds 127.0.0.1; `curl http://127.0.0.1:8000/v1/nodes` works (no key configured)
2. `PRME_API_API_KEY=secret uv run python -m prme.api` — same curl now returns 401; adding `-H "Authorization: Bearer secret"` returns 200; `/v1/health` works without the header
3. `uv run python -m prme.api --host 0.0.0.0` without a key — startup logs a warning about network exposure
4. `curl -H "Origin: http://example.com" -i http://127.0.0.1:8000/v1/health` — no `Access-Control-Allow-Origin` header unless `PRME_API_CORS_ORIGINS` pins that origin
5. `curl http://127.0.0.1:8000/v1/stats?user_id=alice` — returns a count scoped to that user

Fixes #34