### PR TITLE
perf: cut retrieval DB round-trips on the hot path

### DIFF
--- a/src/prme/retrieval/candidates.py
+++ b/src/prme/retrieval/candidates.py
@@ -67,9 +67,10 @@ async def _generate_graph_candidates(
 ) -> list[dict]:
     """Generate candidates from graph neighborhood traversal.
 
-    Seeds are entity nodes matching extracted entity names. For each seed,
-    runs get_neighborhood at 1-hop, 2-hop, and 3-hop to determine per-node
-    hop distances for graph_proximity scoring.
+    Seeds are entity nodes matching extracted entity names (matched in
+    SQL via content LIKE filters). For each seed, runs a single
+    depth-aware neighborhood query to determine per-node hop distances
+    for graph_proximity scoring.
 
     Scope and temporal filters are forwarded to query_nodes() for seed
     discovery and used for post-filter on neighborhood results.
@@ -79,34 +80,17 @@ async def _generate_graph_candidates(
     if not analysis.entities:
         return []
 
-    # Find seed nodes matching extracted entity names.
-    # For multi-scope, iterate and union (query_nodes takes single Scope).
-    if scope is not None and scope:
-        all_entity_nodes = []
-        seen_entity_ids: set[str] = set()
-        for s in scope:
-            nodes = await graph_store.query_nodes(
-                user_id=user_id,
-                node_type=NodeType.ENTITY,
-                scope=s,
-            )
-            for n in nodes:
-                nid = str(n.id)
-                if nid not in seen_entity_ids:
-                    seen_entity_ids.add(nid)
-                    all_entity_nodes.append(n)
-    else:
-        all_entity_nodes = await graph_store.query_nodes(
-            user_id=user_id,
-            node_type=NodeType.ENTITY,
-        )
+    # Find seed nodes matching extracted entity names. The substring
+    # match is pushed into SQL (LOWER(content) LIKE ...) so only matching
+    # entity nodes are hydrated.
+    all_entity_nodes = await graph_store.query_nodes(
+        user_id=user_id,
+        node_type=NodeType.ENTITY,
+        scopes=scope if scope else None,
+        content_contains_any=list(analysis.entities),
+    )
 
-    seed_ids: list[str] = []
-    for node in all_entity_nodes:
-        for entity_name in analysis.entities:
-            if entity_name.lower() in node.content.lower():
-                seed_ids.append(str(node.id))
-                break
+    seed_ids = [str(node.id) for node in all_entity_nodes]
 
     if not seed_ids:
         return []
@@ -114,8 +98,8 @@ async def _generate_graph_candidates(
     # Determine valid_at for neighborhood queries if temporal filter is set.
     valid_at = time_from if time_from is not None else time_to
 
-    # For each seed, determine hop distances via incremental neighborhood
-    # queries: 1-hop, 2-hop (minus 1-hop), 3-hop (minus 1&2-hop).
+    # For each seed, determine hop distances via a single depth-aware
+    # neighborhood query (one traversal instead of one per hop level).
     node_proximity: dict[str, float] = {}  # node_id -> best proximity
     node_map: dict[str, MemoryNode] = {}  # node_id -> MemoryNode
 
@@ -123,42 +107,38 @@ async def _generate_graph_candidates(
     _TEMPORAL_EXEMPT_TYPES = {NodeType.ENTITY, NodeType.PREFERENCE}
 
     max_hops = min(config.graph_max_hops, 3)
+    _HOP_PROXIMITY = {1: 1.0, 2: 0.7, 3: 0.4}
 
     for seed_id in seed_ids:
-        seen_at_previous_hops: set[str] = {seed_id}
+        neighbors = await graph_store.get_neighborhood_with_depth(
+            seed_id, max_hops=max_hops, valid_at=valid_at,
+        )
 
-        for hop in range(1, max_hops + 1):
-            proximity = {1: 1.0, 2: 0.7, 3: 0.4}.get(hop, 0.4)
+        for neighbor, depth in neighbors:
+            nid = str(neighbor.id)
+            if nid == seed_id:
+                continue
+            proximity = _HOP_PROXIMITY.get(depth, 0.4)
 
-            neighbors = await graph_store.get_neighborhood(
-                seed_id, max_hops=hop, valid_at=valid_at,
-            )
+            # Scope filter: skip neighbors outside requested scopes.
+            if scope is not None and scope:
+                if neighbor.scope not in scope:
+                    continue
 
-            for neighbor in neighbors:
-                nid = str(neighbor.id)
-                if nid not in seen_at_previous_hops:
-                    # Scope filter: skip neighbors outside requested scopes.
-                    if scope is not None and scope:
-                        if neighbor.scope not in scope:
-                            continue
+            # Temporal filter: skip nodes outside temporal window,
+            # but exempt ENTITY and PREFERENCE types.
+            if neighbor.node_type not in _TEMPORAL_EXEMPT_TYPES:
+                if time_from is not None and neighbor.valid_to is not None:
+                    if neighbor.valid_to <= time_from:
+                        continue
+                if time_to is not None and neighbor.valid_from is not None:
+                    if neighbor.valid_from > time_to:
+                        continue
 
-                    # Temporal filter: skip nodes outside temporal window,
-                    # but exempt ENTITY and PREFERENCE types.
-                    if neighbor.node_type not in _TEMPORAL_EXEMPT_TYPES:
-                        if time_from is not None and neighbor.valid_to is not None:
-                            if neighbor.valid_to <= time_from:
-                                continue
-                        if time_to is not None and neighbor.valid_from is not None:
-                            if neighbor.valid_from > time_to:
-                                continue
-
-                    # First time seeing this node -- it's at this hop distance.
-                    if nid not in node_proximity or proximity > node_proximity[nid]:
-                        node_proximity[nid] = proximity
-                    node_map[nid] = neighbor
-
-            # Add all IDs from this hop level to seen set.
-            seen_at_previous_hops.update(str(n.id) for n in neighbors)
+            # Keep the best proximity across seeds.
+            if nid not in node_proximity or proximity > node_proximity[nid]:
+                node_proximity[nid] = proximity
+            node_map[nid] = neighbor
 
     # Post-filter to max_candidates: sort by confidence DESC, created_at DESC.
     candidates = [
@@ -246,38 +226,40 @@ async def _generate_pinned_candidates(
 
     Pinned = salience == 1.0. Active tasks = TASK type with lifecycle
     in (TENTATIVE, STABLE). Scope filter limits to requested scopes.
+
+    Both predicates are pushed into SQL (one query each) instead of
+    hydrating a window of recent nodes and filtering in Python.
     """
-    # For multi-scope, iterate and union (query_nodes takes single Scope).
-    if scope is not None and scope:
-        all_nodes = []
-        seen_ids: set[str] = set()
-        for s in scope:
-            nodes = await graph_store.query_nodes(
-                user_id=user_id,
-                scope=s,
-                min_confidence=None,
-                lifecycle_states=[LifecycleState.TENTATIVE, LifecycleState.STABLE],
-                limit=500,
-            )
-            for n in nodes:
-                nid = str(n.id)
-                if nid not in seen_ids:
-                    seen_ids.add(nid)
-                    all_nodes.append(n)
-    else:
-        # No scope filter -- get all active nodes.
-        all_nodes = await graph_store.query_nodes(
+    scopes = scope if scope else None
+    active_states = [LifecycleState.TENTATIVE, LifecycleState.STABLE]
+
+    # Pinned nodes: salience == 1.0 (salience is capped at 1.0, so a
+    # >= 1.0 SQL predicate is equivalent).
+    pinned_nodes, task_nodes = await asyncio.gather(
+        graph_store.query_nodes(
             user_id=user_id,
+            scopes=scopes,
             min_confidence=None,
-            lifecycle_states=[LifecycleState.TENTATIVE, LifecycleState.STABLE],
+            min_salience=1.0,
+            lifecycle_states=active_states,
             limit=500,
-        )
+        ),
+        graph_store.query_nodes(
+            user_id=user_id,
+            scopes=scopes,
+            node_type=NodeType.TASK,
+            min_confidence=None,
+            lifecycle_states=active_states,
+            limit=500,
+        ),
+    )
 
     pinned: list[MemoryNode] = []
-    for node in all_nodes:
-        is_pinned = node.salience == 1.0
-        is_active_task = node.node_type == NodeType.TASK
-        if is_pinned or is_active_task:
+    seen_ids: set[str] = set()
+    for node in [*pinned_nodes, *task_nodes]:
+        nid = str(node.id)
+        if nid not in seen_ids:
+            seen_ids.add(nid)
             pinned.append(node)
 
     return pinned
@@ -392,6 +374,16 @@ def merge_candidates(
     return merged
 
 
+async def _empty_graph_candidates() -> list[dict]:
+    """No-op graph backend used when graph candidates are disabled."""
+    return []
+
+
+async def _empty_pinned_candidates() -> list[MemoryNode]:
+    """No-op pinned backend used when pinned candidates are disabled."""
+    return []
+
+
 async def generate_candidates(
     analysis: QueryAnalysis,
     *,
@@ -403,6 +395,8 @@ async def generate_candidates(
     time_from: datetime | None = None,
     time_to: datetime | None = None,
     config: PackingConfig = DEFAULT_PACKING_CONFIG,
+    include_graph: bool = True,
+    include_pinned: bool = True,
 ) -> tuple[list[RetrievalCandidate], dict[str, int]]:
     """Generate and merge candidates from all four backends in parallel.
 
@@ -423,17 +417,23 @@ async def generate_candidates(
         time_to: Optional temporal window end. Forwarded to graph and
             vector backends. ENTITY and PREFERENCE types are exempt.
         config: PackingConfig controlling candidate limits.
+        include_graph: Run the graph neighborhood backend. Disabled for
+            cheap secondary passes (e.g. cross-scope hints).
+        include_pinned: Run the pinned/active-task backend. Disabled for
+            cheap secondary passes (e.g. cross-scope hints).
 
     Returns:
         Tuple of (merged_candidates, candidate_counts_per_backend).
         candidate_counts_per_backend maps backend name to pre-merge count.
     """
-    # Run all four backends in parallel, forwarding scope and temporal filters.
+    # Run the enabled backends in parallel, forwarding scope and temporal
+    # filters. Disabled backends are replaced with no-op coroutines so
+    # result unpacking stays positional.
     results = await asyncio.gather(
         _generate_graph_candidates(
             analysis, graph_store, user_id, config,
             scope=scope, time_from=time_from, time_to=time_to,
-        ),
+        ) if include_graph else _empty_graph_candidates(),
         _generate_vector_candidates(
             analysis, vector_index, user_id, config,
             scope=scope, time_from=time_from, time_to=time_to,
@@ -442,7 +442,8 @@ async def generate_candidates(
             analysis, lexical_index, user_id, config,
             scope=scope,
         ),
-        _generate_pinned_candidates(graph_store, user_id, scope=scope),
+        _generate_pinned_candidates(graph_store, user_id, scope=scope)
+        if include_pinned else _empty_pinned_candidates(),
         return_exceptions=True,
     )
 
@@ -502,10 +503,11 @@ async def generate_candidates(
     for node in pinned_cands:
         resolved_nodes[str(node.id)] = node
 
-    for node_id in node_ids_to_resolve:
-        node = await graph_store.get_node(node_id)
-        if node is not None:
-            resolved_nodes[node_id] = node
+    # Batch resolution: one WHERE id IN (...) round trip instead of one
+    # sequential get_node() call per candidate.
+    if node_ids_to_resolve:
+        for node in await graph_store.get_nodes(list(node_ids_to_resolve)):
+            resolved_nodes[str(node.id)] = node
 
     # Merge all candidates.
     merged = merge_candidates(

--- a/src/prme/retrieval/pipeline.py
+++ b/src/prme/retrieval/pipeline.py
@@ -231,24 +231,41 @@ class RetrievalPipeline:
                 # Also try bigrams
                 for i in range(len(search_terms) - 1):
                     search_terms.append(f"{keywords[i]} {keywords[i+1]}")
+            # Run all term searches concurrently, then resolve the unique
+            # hits with a single batched node fetch (instead of sequential
+            # searches with one get_node round trip per hit).
+            term_results = await asyncio.gather(
+                *[
+                    self._lexical_index.search(term, user_id=user_id, limit=50)
+                    for term in search_terms
+                ],
+                return_exceptions=True,
+            )
             agg_seen_ids: set[str] = set()
-            for term in search_terms:
+            agg_hits: list[dict] = []
+            for hits in term_results:
+                if isinstance(hits, BaseException):
+                    continue
+                for hit in hits:
+                    nid = hit["node_id"]
+                    if nid not in agg_seen_ids:
+                        agg_seen_ids.add(nid)
+                        agg_hits.append(hit)
+            if agg_hits:
                 try:
-                    hits = await self._lexical_index.search(
-                        term, user_id=user_id, limit=50,
+                    agg_nodes = await self._graph_store.get_nodes(
+                        [hit["node_id"] for hit in agg_hits]
                     )
-                    for hit in hits:
-                        nid = hit["node_id"]
-                        if nid not in agg_seen_ids:
-                            agg_seen_ids.add(nid)
-                            node = await self._graph_store.get_node(nid)
-                            if node is not None:
-                                aggregation_extra.append(RetrievalCandidate(
-                                    node=node,
-                                    paths=["LEXICAL"],
-                                    path_count=1,
-                                    lexical_score=hit.get("score", 0.0),
-                                ))
+                    agg_node_map = {str(n.id): n for n in agg_nodes}
+                    for hit in agg_hits:
+                        node = agg_node_map.get(hit["node_id"])
+                        if node is not None:
+                            aggregation_extra.append(RetrievalCandidate(
+                                node=node,
+                                paths=["LEXICAL"],
+                                path_count=1,
+                                lexical_score=hit.get("score", 0.0),
+                            ))
                 except Exception:
                     pass
 
@@ -283,19 +300,39 @@ class RetrievalPipeline:
         # misses (e.g., "Sweden" mentioned once in a tangential context).
         if analysis.entities:
             existing_ids = {str(c.node.id) for c in candidates}
-            for entity_name in analysis.entities[:3]:
-                try:
-                    entity_hits = await self._lexical_index.search(
-                        entity_name,
-                        user_id=user_id,
-                        limit=20,
+            # Run the per-entity searches concurrently, then resolve the
+            # unique new hits with a single batched node fetch.
+            entity_names = analysis.entities[:3]
+            entity_results = await asyncio.gather(
+                *[
+                    self._lexical_index.search(name, user_id=user_id, limit=20)
+                    for name in entity_names
+                ],
+                return_exceptions=True,
+            )
+            entity_hits: list[dict] = []
+            for name, hits in zip(entity_names, entity_results):
+                if isinstance(hits, BaseException):
+                    logger.debug(
+                        "Entity-focused retrieval failed for '%s'; continuing",
+                        name,
+                        exc_info=hits,
                     )
+                    continue
+                for hit in hits:
+                    nid = hit["node_id"]
+                    if nid in existing_ids:
+                        continue
+                    existing_ids.add(nid)
+                    entity_hits.append(hit)
+            if entity_hits:
+                try:
+                    entity_nodes = await self._graph_store.get_nodes(
+                        [hit["node_id"] for hit in entity_hits]
+                    )
+                    entity_node_map = {str(n.id): n for n in entity_nodes}
                     for hit in entity_hits:
-                        nid = hit["node_id"]
-                        if nid in existing_ids:
-                            continue
-                        existing_ids.add(nid)
-                        node = await self._graph_store.get_node(nid)
+                        node = entity_node_map.get(hit["node_id"])
                         if node is not None:
                             candidates.append(RetrievalCandidate(
                                 node=node,
@@ -306,8 +343,7 @@ class RetrievalPipeline:
                             candidate_counts["LEXICAL"] = candidate_counts.get("LEXICAL", 0) + 1
                 except Exception:
                     logger.debug(
-                        "Entity-focused retrieval failed for '%s'; continuing",
-                        entity_name,
+                        "Entity-focused node resolution failed; continuing",
                         exc_info=True,
                     )
 
@@ -375,14 +411,22 @@ class RetrievalPipeline:
             if c.node.lifecycle_state == LifecycleState.CONTESTED
         ]
         if contested_ids:
+            # Fetch CONTRADICTS edges touching ANY contested node in one
+            # batched query (instead of 2 queries per contested node),
+            # and index scored candidates by id once.
+            contradicts_edges = await self._graph_store.get_edges(
+                node_ids=contested_ids, edge_type=EdgeType.CONTRADICTS
+            )
+            scored_by_id = {str(c.node.id): c for c in scored}
             for cid in contested_ids:
-                # Look up CONTRADICTS edges in both directions
-                edges_out = await self._graph_store.get_edges(
-                    source_id=cid, edge_type=EdgeType.CONTRADICTS
-                )
-                edges_in = await self._graph_store.get_edges(
-                    target_id=cid, edge_type=EdgeType.CONTRADICTS
-                )
+                # Preserve direction priority: outgoing edges first, then
+                # incoming, matching the previous per-node query order.
+                edges_out = [
+                    e for e in contradicts_edges if str(e.source_id) == cid
+                ]
+                edges_in = [
+                    e for e in contradicts_edges if str(e.target_id) == cid
+                ]
                 all_edges = edges_out + edges_in
                 if all_edges:
                     # Find the counterpart node ID
@@ -392,10 +436,10 @@ class RetrievalPipeline:
                         else str(edge.source_id)
                     )
                     # Annotate the candidate
-                    for c in scored:
-                        if str(c.node.id) == cid:
-                            c.conflict_flag = True
-                            c.contradicts_id = uuid.UUID(counterpart_id)
+                    candidate = scored_by_id.get(cid)
+                    if candidate is not None:
+                        candidate.conflict_flag = True
+                        candidate.contradicts_id = uuid.UUID(counterpart_id)
 
         # --- Stage 5.5b: Session Context Expansion ---
         # After scoring, expand top results with adjacent turns from the
@@ -431,6 +475,9 @@ class RetrievalPipeline:
                     }
                 )
                 # Secondary generation: no scope filter, WITH temporal filter.
+                # Cheapest backends only (vector + lexical): the graph and
+                # pinned backends are skipped so the hint pass doesn't
+                # repeat the full candidate pipeline.
                 hint_candidates, _ = await generate_candidates(
                     analysis,
                     graph_store=self._graph_store,
@@ -441,6 +488,8 @@ class RetrievalPipeline:
                     time_from=effective_time_from,
                     time_to=effective_time_to,
                     config=hint_config,
+                    include_graph=False,
+                    include_pinned=False,
                 )
                 # Filter to only results NOT in primary scopes.
                 primary_scope_values = {s.value for s in normalized_scope}

--- a/src/prme/retrieval/session_context.py
+++ b/src/prme/retrieval/session_context.py
@@ -74,11 +74,14 @@ async def expand_session_context(
     if not session_triggers:
         return scored
 
-    # Fetch all nodes once and group by session_id (avoids repeated queries).
+    # Fetch the triggering sessions' nodes in one query (session_id IN
+    # (...) is pushed into SQL instead of hydrating the newest 2000 nodes
+    # and filtering in Python).
     session_nodes: dict[str, list[MemoryNode]] = {}
     try:
         all_nodes = await graph_store.query_nodes(
             user_id=user_id,
+            session_ids=list(session_triggers.keys()),
             limit=2000,
         )
         for n in all_nodes:

--- a/src/prme/storage/duckpgq_graph.py
+++ b/src/prme/storage/duckpgq_graph.py
@@ -22,14 +22,11 @@ from prme.models.edges import MemoryEdge
 from prme.models.nodes import MemoryNode
 from prme.types import (
     ACTIVE_LIFECYCLE_STATES,
-    ALLOWED_TRANSITIONS,
     DecayProfile,
     EdgeType,
-    EpistemicType,
     LifecycleState,
     NodeType,
     Scope,
-    SourceType,
     validate_transition,
 )
 
@@ -88,15 +85,45 @@ class DuckPGQGraphStore:
                 self._get_node_sync, node_id, include_superseded
             )
 
+    async def get_nodes(
+        self,
+        node_ids: list[str],
+        *,
+        include_superseded: bool = False,
+    ) -> list[MemoryNode]:
+        """Retrieve multiple nodes by ID in a single round trip.
+
+        Batch equivalent of get_node() with identical visibility
+        semantics. Missing IDs are silently omitted.
+
+        Args:
+            node_ids: String UUIDs of the nodes to fetch.
+            include_superseded: If False, superseded/archived nodes
+                are omitted.
+
+        Returns:
+            List of found, visible MemoryNodes.
+        """
+        if not node_ids:
+            return []
+        async with self._conn_lock:
+            return await asyncio.to_thread(
+                self._get_nodes_sync, node_ids, include_superseded
+            )
+
     async def query_nodes(
         self,
         *,
         node_type: NodeType | None = None,
         user_id: str | None = None,
         scope: Scope | None = None,
+        scopes: list[Scope] | None = None,
+        session_ids: list[str] | None = None,
         lifecycle_states: list[LifecycleState] | None = None,
         valid_at: datetime | None = None,
         min_confidence: float | None = None,
+        min_salience: float | None = None,
+        content_contains_any: list[str] | None = None,
         limit: int = 100,
     ) -> list[MemoryNode]:
         """Query nodes with flexible filters.
@@ -106,10 +133,15 @@ class DuckPGQGraphStore:
         Args:
             node_type: Filter by node type.
             user_id: Filter by user.
-            scope: Filter by scope.
+            scope: Filter by a single scope.
+            scopes: Filter by multiple scopes (scope IN (...)).
+            session_ids: Filter by session IDs (session_id IN (...)).
             lifecycle_states: Lifecycle filter (defaults to active).
             valid_at: Temporal validity filter.
             min_confidence: Minimum confidence threshold.
+            min_salience: Minimum salience threshold.
+            content_contains_any: Case-insensitive substring filters
+                (matches content containing ANY of the strings).
             limit: Max results.
 
         Returns:
@@ -121,9 +153,13 @@ class DuckPGQGraphStore:
                 node_type,
                 user_id,
                 scope,
+                scopes,
+                session_ids,
                 lifecycle_states,
                 valid_at,
                 min_confidence,
+                min_salience,
+                content_contains_any,
                 limit,
             )
 
@@ -185,6 +221,7 @@ class DuckPGQGraphStore:
         *,
         source_id: str | None = None,
         target_id: str | None = None,
+        node_ids: list[str] | None = None,
         edge_type: EdgeType | None = None,
         valid_at: datetime | None = None,
         min_confidence: float | None = None,
@@ -194,6 +231,8 @@ class DuckPGQGraphStore:
         Args:
             source_id: Filter by source node.
             target_id: Filter by target node.
+            node_ids: Filter to edges touching ANY of these node IDs
+                (source or target).
             edge_type: Filter by edge type.
             valid_at: Temporal validity filter.
             min_confidence: Minimum confidence threshold.
@@ -206,6 +245,7 @@ class DuckPGQGraphStore:
                 self._get_edges_sync,
                 source_id,
                 target_id,
+                node_ids,
                 edge_type,
                 valid_at,
                 min_confidence,
@@ -376,6 +416,45 @@ class DuckPGQGraphStore:
         async with self._conn_lock:
             return await asyncio.to_thread(
                 self._get_neighborhood_sync,
+                node_id,
+                max_hops,
+                edge_types,
+                valid_at,
+                min_confidence,
+                include_superseded,
+            )
+
+    async def get_neighborhood_with_depth(
+        self,
+        node_id: str,
+        *,
+        max_hops: int = 2,
+        edge_types: list[EdgeType] | None = None,
+        valid_at: datetime | None = None,
+        min_confidence: float | None = None,
+        include_superseded: bool = False,
+    ) -> list[tuple[MemoryNode, int]]:
+        """Get nodes within N hops along with their minimum hop distance.
+
+        Runs a single cycle-guarded recursive CTE and returns each
+        reachable node once with MIN(depth), so callers don't need to
+        re-traverse the neighborhood per hop level.
+
+        Args:
+            node_id: Starting node ID.
+            max_hops: Maximum number of hops (default 2).
+            edge_types: Only traverse edges of these types.
+            valid_at: Temporal filter for nodes.
+            min_confidence: Minimum node confidence.
+            include_superseded: Include superseded/archived nodes.
+
+        Returns:
+            List of (MemoryNode, min_depth) tuples, excluding the
+            starting node.
+        """
+        async with self._conn_lock:
+            return await asyncio.to_thread(
+                self._get_neighborhood_with_depth_sync,
                 node_id,
                 max_hops,
                 edge_types,
@@ -625,14 +704,43 @@ class DuckPGQGraphStore:
             return None
         return self._row_to_node(result)
 
+    def _get_nodes_sync(
+        self, node_ids: list[str], include_superseded: bool
+    ) -> list[MemoryNode]:
+        """Retrieve multiple nodes by ID with one IN query (sync)."""
+        placeholders = ", ".join(["?" for _ in node_ids])
+        if include_superseded:
+            query = f"SELECT * FROM nodes WHERE id IN ({placeholders})"
+        else:
+            query = f"""
+                SELECT * FROM nodes
+                WHERE id IN ({placeholders})
+                AND lifecycle_state IN ('tentative', 'stable')
+            """
+        rows = self._conn.execute(query, list(node_ids)).fetchall()
+        return [self._row_to_node(row) for row in rows]
+
+    @staticmethod
+    def _escape_like(pattern: str) -> str:
+        """Escape LIKE wildcards in a user-supplied substring."""
+        return (
+            pattern.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+
     def _query_nodes_sync(
         self,
         node_type: NodeType | None,
         user_id: str | None,
         scope: Scope | None,
+        scopes: list[Scope] | None,
+        session_ids: list[str] | None,
         lifecycle_states: list[LifecycleState] | None,
         valid_at: datetime | None,
         min_confidence: float | None,
+        min_salience: float | None,
+        content_contains_any: list[str] | None,
         limit: int,
     ) -> list[MemoryNode]:
         """Query nodes with dynamic WHERE clause (sync)."""
@@ -662,6 +770,16 @@ class DuckPGQGraphStore:
             conditions.append("scope = ?")
             params.append(scope.value)
 
+        if scopes is not None and scopes:
+            scope_placeholders = ", ".join(["?" for _ in scopes])
+            conditions.append(f"scope IN ({scope_placeholders})")
+            params.extend([s.value for s in scopes])
+
+        if session_ids is not None and session_ids:
+            sid_placeholders = ", ".join(["?" for _ in session_ids])
+            conditions.append(f"session_id IN ({sid_placeholders})")
+            params.extend(session_ids)
+
         if valid_at is not None:
             conditions.append(
                 "valid_from <= ? AND (valid_to IS NULL OR valid_to > ?)"
@@ -671,6 +789,19 @@ class DuckPGQGraphStore:
         if min_confidence is not None:
             conditions.append("confidence >= ?")
             params.append(min_confidence)
+
+        if min_salience is not None:
+            conditions.append("salience >= ?")
+            params.append(min_salience)
+
+        if content_contains_any is not None and content_contains_any:
+            like_clauses = " OR ".join(
+                ["LOWER(content) LIKE ? ESCAPE '\\'" for _ in content_contains_any]
+            )
+            conditions.append(f"({like_clauses})")
+            params.extend(
+                f"%{self._escape_like(p.lower())}%" for p in content_contains_any
+            )
 
         where_clause = " AND ".join(conditions) if conditions else "1=1"
         query = f"""
@@ -748,6 +879,7 @@ class DuckPGQGraphStore:
         self,
         source_id: str | None,
         target_id: str | None,
+        node_ids: list[str] | None,
         edge_type: EdgeType | None,
         valid_at: datetime | None,
         min_confidence: float | None,
@@ -763,6 +895,15 @@ class DuckPGQGraphStore:
         if target_id is not None:
             conditions.append("target_id = ?")
             params.append(target_id)
+
+        if node_ids is not None and node_ids:
+            id_placeholders = ", ".join(["?" for _ in node_ids])
+            conditions.append(
+                f"(source_id IN ({id_placeholders}) "
+                f"OR target_id IN ({id_placeholders}))"
+            )
+            params.extend(node_ids)
+            params.extend(node_ids)
 
         if edge_type is not None:
             conditions.append("edge_type = ?")
@@ -1185,9 +1326,35 @@ class DuckPGQGraphStore:
     ) -> list[MemoryNode]:
         """Get neighborhood via recursive CTE (sync).
 
-        Traverses edges in both directions to find the full neighborhood.
-        Uses a single UNION ALL recursive CTE with bidirectional traversal
-        in both the base and recursive cases.
+        Delegates to the depth-aware variant and discards depths -- the
+        reachable node set is identical.
+        """
+        results = self._get_neighborhood_with_depth_sync(
+            node_id,
+            max_hops,
+            edge_types,
+            valid_at,
+            min_confidence,
+            include_superseded,
+        )
+        return [node for node, _depth in results]
+
+    def _get_neighborhood_with_depth_sync(
+        self,
+        node_id: str,
+        max_hops: int,
+        edge_types: list[EdgeType] | None,
+        valid_at: datetime | None,
+        min_confidence: float | None,
+        include_superseded: bool,
+    ) -> list[tuple[MemoryNode, int]]:
+        """Get neighborhood with min hop depth via recursive CTE (sync).
+
+        Traverses edges in both directions. The recursive CTE tracks the
+        path of visited nodes per branch and refuses to revisit a node
+        already on the path (cycle guard), preventing A->B->A oscillation
+        from enumerating exponentially many paths. Each reachable node is
+        returned once with its minimum depth (GROUP BY id, MIN(depth)).
         """
         logger.debug(
             "get_neighborhood using recursive CTE (SQL fallback)",
@@ -1231,7 +1398,10 @@ class DuckPGQGraphStore:
 
         # Recursive CTE: base case finds direct neighbors (both directions),
         # recursive case expands from there. Uses CASE to handle bidirectional
-        # traversal in a single UNION ALL.
+        # traversal in a single UNION ALL. Each branch carries the list of
+        # nodes on its path; the recursive step skips nodes already visited
+        # on that path (cycle guard). The outer query collapses paths to one
+        # row per node with the minimum depth.
         query = f"""
             WITH RECURSIVE neighborhood AS (
                 -- Base case: direct neighbors in both directions
@@ -1240,33 +1410,59 @@ class DuckPGQGraphStore:
                          THEN e.target_id
                          ELSE e.source_id
                     END AS id,
-                    1 AS depth
+                    1 AS depth,
+                    [CAST(? AS UUID),
+                     CASE WHEN e.source_id = CAST(? AS UUID)
+                          THEN e.target_id
+                          ELSE e.source_id
+                     END] AS path
                 FROM edges e
                 WHERE (e.source_id = CAST(? AS UUID) OR e.target_id = CAST(? AS UUID))
                     {edge_where}
 
                 UNION ALL
 
-                -- Recursive case: expand from discovered neighbors
+                -- Recursive case: expand from discovered neighbors,
+                -- skipping nodes already on this branch's path.
                 SELECT
                     CASE WHEN e.source_id = nb.id
                          THEN e.target_id
                          ELSE e.source_id
                     END AS id,
-                    nb.depth + 1 AS depth
+                    nb.depth + 1 AS depth,
+                    list_append(
+                        nb.path,
+                        CASE WHEN e.source_id = nb.id
+                             THEN e.target_id
+                             ELSE e.source_id
+                        END
+                    ) AS path
                 FROM neighborhood nb
                 JOIN edges e ON (e.source_id = nb.id OR e.target_id = nb.id)
                     {edge_where}
                 WHERE nb.depth < ?
+                    AND NOT list_contains(
+                        nb.path,
+                        CASE WHEN e.source_id = nb.id
+                             THEN e.target_id
+                             ELSE e.source_id
+                        END
+                    )
             )
-            SELECT DISTINCT n.*
-            FROM neighborhood nb
+            SELECT n.*, nb.min_depth
+            FROM (
+                SELECT id, MIN(depth) AS min_depth
+                FROM neighborhood
+                GROUP BY id
+            ) nb
             JOIN nodes n ON nb.id = n.id
             WHERE n.id != CAST(? AS UUID) {node_where}
         """
 
         params: list = []
-        # Base case: 3 refs to node_id + edge_params
+        # Base case: 5 refs to node_id + edge_params
+        params.append(node_id)
+        params.append(node_id)
         params.append(node_id)
         params.append(node_id)
         params.append(node_id)
@@ -1279,7 +1475,9 @@ class DuckPGQGraphStore:
         params.extend(node_params)
 
         rows = self._conn.execute(query, params).fetchall()
-        return [self._row_to_node(row) for row in rows]
+        # The depth column trails the full nodes row; _row_to_node reads
+        # fixed positions and ignores trailing columns.
+        return [(self._row_to_node(row), int(row[-1])) for row in rows]
 
     def _find_shortest_path_sync(
         self,

--- a/src/prme/storage/graph_store.py
+++ b/src/prme/storage/graph_store.py
@@ -60,15 +60,42 @@ class GraphStore(Protocol):
         """
         ...
 
+    async def get_nodes(
+        self,
+        node_ids: list[str],
+        *,
+        include_superseded: bool = False,
+    ) -> list[MemoryNode]:
+        """Retrieve multiple nodes by ID in a single round trip.
+
+        Batch equivalent of get_node() — one ``WHERE id IN (...)`` query
+        instead of N sequential lookups. Visibility semantics match
+        get_node(): superseded/archived nodes are excluded unless
+        include_superseded is True. Missing IDs are silently omitted.
+
+        Args:
+            node_ids: String UUIDs of the nodes to fetch.
+            include_superseded: If False (default), superseded/archived
+                nodes are omitted from the result.
+
+        Returns:
+            List of found, visible MemoryNodes (order not guaranteed).
+        """
+        ...
+
     async def query_nodes(
         self,
         *,
         node_type: NodeType | None = None,
         user_id: str | None = None,
         scope: Scope | None = None,
+        scopes: list[Scope] | None = None,
+        session_ids: list[str] | None = None,
         lifecycle_states: list[LifecycleState] | None = None,
         valid_at: datetime | None = None,
         min_confidence: float | None = None,
+        min_salience: float | None = None,
+        content_contains_any: list[str] | None = None,
         limit: int = 100,
     ) -> list[MemoryNode]:
         """Query nodes with filters.
@@ -76,11 +103,18 @@ class GraphStore(Protocol):
         Args:
             node_type: Filter by node type.
             user_id: Filter by owner user.
-            scope: Filter by memory scope.
+            scope: Filter by a single memory scope.
+            scopes: Filter by multiple scopes (``scope IN (...)``).
+                Mutually exclusive with ``scope``.
+            session_ids: Filter by session IDs (``session_id IN (...)``).
             lifecycle_states: Filter by lifecycle states. Defaults to
                 active states (TENTATIVE, STABLE, CONTESTED).
             valid_at: Temporal filter -- return nodes valid at this time.
             min_confidence: Minimum confidence threshold.
+            min_salience: Minimum salience threshold.
+            content_contains_any: Case-insensitive substring filters --
+                matches nodes whose content contains ANY of the given
+                strings (pushed into SQL as LIKE clauses).
             limit: Maximum results to return.
 
         Returns:
@@ -143,6 +177,7 @@ class GraphStore(Protocol):
         *,
         source_id: str | None = None,
         target_id: str | None = None,
+        node_ids: list[str] | None = None,
         edge_type: EdgeType | None = None,
         valid_at: datetime | None = None,
         min_confidence: float | None = None,
@@ -152,6 +187,9 @@ class GraphStore(Protocol):
         Args:
             source_id: Filter by source node ID.
             target_id: Filter by target node ID.
+            node_ids: Filter to edges touching ANY of these node IDs
+                (``source_id IN (...) OR target_id IN (...)``). Batch
+                equivalent of querying each node in both directions.
             edge_type: Filter by edge type.
             valid_at: Temporal filter.
             min_confidence: Minimum confidence threshold.
@@ -185,6 +223,36 @@ class GraphStore(Protocol):
 
         Returns:
             List of reachable MemoryNodes (excluding the starting node).
+        """
+        ...
+
+    async def get_neighborhood_with_depth(
+        self,
+        node_id: str,
+        *,
+        max_hops: int = 2,
+        edge_types: list[EdgeType] | None = None,
+        valid_at: datetime | None = None,
+        min_confidence: float | None = None,
+        include_superseded: bool = False,
+    ) -> list[tuple[MemoryNode, int]]:
+        """Get nodes within N hops along with their minimum hop distance.
+
+        Single-query variant of get_neighborhood() that also returns the
+        minimum depth at which each node was reached, so callers can
+        derive hop-distance scores without re-traversing per hop level.
+
+        Args:
+            node_id: Starting node ID.
+            max_hops: Maximum number of hops (default 2).
+            edge_types: Only traverse edges of these types.
+            valid_at: Temporal filter for edges.
+            min_confidence: Minimum edge confidence.
+            include_superseded: Include superseded/archived nodes.
+
+        Returns:
+            List of (MemoryNode, min_depth) tuples, excluding the
+            starting node. min_depth is 1 for direct neighbors.
         """
         ...
 

--- a/src/prme/storage/pg/graph_store.py
+++ b/src/prme/storage/pg/graph_store.py
@@ -21,11 +21,9 @@ from prme.types import (
     ACTIVE_LIFECYCLE_STATES,
     DecayProfile,
     EdgeType,
-    EpistemicType,
     LifecycleState,
     NodeType,
     Scope,
-    SourceType,
     validate_transition,
 )
 
@@ -39,6 +37,12 @@ _NODE_COLUMNS = (
     "created_at, updated_at, epistemic_type, source_type, "
     "decay_profile, last_reinforced_at, reinforcement_boost, "
     "salience_base, confidence_base, pinned"
+)
+
+# Node columns qualified with the "n." alias for queries that join
+# nodes against other relations exposing an "id" column.
+_NODE_COLUMNS_QUALIFIED = ", ".join(
+    f"n.{col.strip()}" for col in _NODE_COLUMNS.split(",")
 )
 
 _EDGE_COLUMNS = (
@@ -136,15 +140,56 @@ class PgGraphStore:
             return None
         return self._record_to_node(row)
 
+    async def get_nodes(
+        self,
+        node_ids: list[str],
+        *,
+        include_superseded: bool = False,
+    ) -> list[MemoryNode]:
+        """Retrieve multiple nodes by ID in a single round trip.
+
+        Batch equivalent of get_node() with identical visibility
+        semantics. Missing IDs are silently omitted.
+        """
+        if not node_ids:
+            return []
+        if include_superseded:
+            query = (
+                f"SELECT {_NODE_COLUMNS} FROM nodes "
+                "WHERE id = ANY($1::uuid[])"
+            )
+        else:
+            query = (
+                f"SELECT {_NODE_COLUMNS} FROM nodes "
+                "WHERE id = ANY($1::uuid[]) "
+                "AND lifecycle_state IN ('tentative', 'stable')"
+            )
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(query, node_ids)
+        return [self._record_to_node(row) for row in rows]
+
+    @staticmethod
+    def _escape_like(pattern: str) -> str:
+        """Escape LIKE wildcards in a user-supplied substring."""
+        return (
+            pattern.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+
     async def query_nodes(
         self,
         *,
         node_type: NodeType | None = None,
         user_id: str | None = None,
         scope: Scope | None = None,
+        scopes: list[Scope] | None = None,
+        session_ids: list[str] | None = None,
         lifecycle_states: list[LifecycleState] | None = None,
         valid_at: datetime | None = None,
         min_confidence: float | None = None,
+        min_salience: float | None = None,
+        content_contains_any: list[str] | None = None,
         limit: int = 100,
     ) -> list[MemoryNode]:
         """Query nodes with flexible filters."""
@@ -175,6 +220,16 @@ class PgGraphStore:
             params.append(scope.value)
             idx += 1
 
+        if scopes is not None and scopes:
+            conditions.append(f"scope = ANY(${idx}::text[])")
+            params.append([s.value for s in scopes])
+            idx += 1
+
+        if session_ids is not None and session_ids:
+            conditions.append(f"session_id = ANY(${idx}::text[])")
+            params.append(list(session_ids))
+            idx += 1
+
         if valid_at is not None:
             conditions.append(
                 f"valid_from <= ${idx} AND (valid_to IS NULL OR valid_to > ${idx + 1})"
@@ -185,6 +240,18 @@ class PgGraphStore:
         if min_confidence is not None:
             conditions.append(f"confidence >= ${idx}")
             params.append(min_confidence)
+            idx += 1
+
+        if min_salience is not None:
+            conditions.append(f"salience >= ${idx}")
+            params.append(min_salience)
+            idx += 1
+
+        if content_contains_any is not None and content_contains_any:
+            conditions.append(f"LOWER(content) LIKE ANY(${idx}::text[])")
+            params.append(
+                [f"%{self._escape_like(p.lower())}%" for p in content_contains_any]
+            )
             idx += 1
 
         where = " AND ".join(conditions) if conditions else "1=1"
@@ -362,6 +429,7 @@ class PgGraphStore:
         *,
         source_id: str | None = None,
         target_id: str | None = None,
+        node_ids: list[str] | None = None,
         edge_type: EdgeType | None = None,
         valid_at: datetime | None = None,
         min_confidence: float | None = None,
@@ -379,6 +447,14 @@ class PgGraphStore:
         if target_id is not None:
             conditions.append(f"target_id = ${idx}::uuid")
             params.append(target_id)
+            idx += 1
+
+        if node_ids is not None and node_ids:
+            conditions.append(
+                f"(source_id = ANY(${idx}::uuid[]) "
+                f"OR target_id = ANY(${idx}::uuid[]))"
+            )
+            params.append(list(node_ids))
             idx += 1
 
         if edge_type is not None:
@@ -751,7 +827,38 @@ class PgGraphStore:
         min_confidence: float | None = None,
         include_superseded: bool = False,
     ) -> list[MemoryNode]:
-        """Get nodes within N hops of a starting node via recursive CTE."""
+        """Get nodes within N hops of a starting node via recursive CTE.
+
+        Delegates to the depth-aware variant and discards depths -- the
+        reachable node set is identical.
+        """
+        results = await self.get_neighborhood_with_depth(
+            node_id,
+            max_hops=max_hops,
+            edge_types=edge_types,
+            valid_at=valid_at,
+            min_confidence=min_confidence,
+            include_superseded=include_superseded,
+        )
+        return [node for node, _depth in results]
+
+    async def get_neighborhood_with_depth(
+        self,
+        node_id: str,
+        *,
+        max_hops: int = 2,
+        edge_types: list[EdgeType] | None = None,
+        valid_at: datetime | None = None,
+        min_confidence: float | None = None,
+        include_superseded: bool = False,
+    ) -> list[tuple[MemoryNode, int]]:
+        """Get nodes within N hops with their minimum hop distance.
+
+        Single cycle-guarded recursive CTE: each branch carries the array
+        of visited node IDs and refuses to revisit one (preventing
+        A->B->A oscillation), and the outer query collapses paths to one
+        row per node with MIN(depth).
+        """
         # Build edge filter
         edge_filter_parts: list[str] = []
         params: list = [node_id]
@@ -800,34 +907,54 @@ class PgGraphStore:
                          THEN e.target_id
                          ELSE e.source_id
                     END AS id,
-                    1 AS depth
+                    1 AS depth,
+                    ARRAY[$1::uuid,
+                          CASE WHEN e.source_id = $1::uuid
+                               THEN e.target_id
+                               ELSE e.source_id
+                          END] AS path
                 FROM edges e
                 WHERE (e.source_id = $1::uuid OR e.target_id = $1::uuid)
                     {edge_filter}
 
-                UNION
+                UNION ALL
 
-                -- Recursive case
+                -- Recursive case: expand from discovered neighbors,
+                -- skipping nodes already on this branch's path.
                 SELECT
                     CASE WHEN e.source_id = nb.id
                          THEN e.target_id
                          ELSE e.source_id
                     END AS id,
-                    nb.depth + 1 AS depth
+                    nb.depth + 1 AS depth,
+                    nb.path || CASE WHEN e.source_id = nb.id
+                                    THEN e.target_id
+                                    ELSE e.source_id
+                               END AS path
                 FROM neighborhood nb
                 JOIN edges e ON (e.source_id = nb.id OR e.target_id = nb.id)
                     {edge_filter}
                 WHERE nb.depth < ${max_hops_idx}
+                    AND CASE WHEN e.source_id = nb.id
+                             THEN e.target_id
+                             ELSE e.source_id
+                        END != ALL(nb.path)
             )
-            SELECT DISTINCT {_NODE_COLUMNS}
-            FROM (SELECT DISTINCT id FROM neighborhood) nb_ids
-            JOIN nodes n ON nb_ids.id = n.id
+            SELECT {_NODE_COLUMNS_QUALIFIED}, nb.min_depth
+            FROM (
+                SELECT id, MIN(depth) AS min_depth
+                FROM neighborhood
+                GROUP BY id
+            ) nb
+            JOIN nodes n ON nb.id = n.id
             WHERE n.id != $1::uuid {node_filter}
         """
 
         async with self._pool.acquire() as conn:
             rows = await conn.fetch(query, *params)
-        return [self._record_to_node(row) for row in rows]
+        return [
+            (self._record_to_node(row), int(row["min_depth"])) for row in rows
+        ]
 
     async def find_shortest_path(
         self,

--- a/src/prme/storage/vector_index.py
+++ b/src/prme/storage/vector_index.py
@@ -26,8 +26,9 @@ class VectorIndex:
     version, and dimension for re-embedding detection after model switches.
 
     User_id filtering uses post-filter strategy: retrieve extra candidates
-    from USearch, then filter by user_id via metadata lookup. This is
-    simpler and sufficient for Phase 1 scale.
+    from USearch, then validate only those matched keys against the
+    metadata table (WHERE vector_key IN (...)), so the lookup is bounded
+    by the over-fetch size rather than the user's total vector count.
 
     Args:
         conn: DuckDB connection for metadata storage.
@@ -95,50 +96,51 @@ class VectorIndex:
         scope: list[str] | None,
         time_from: datetime | None,
         time_to: datetime | None,
+        candidate_keys: list[int],
     ) -> dict[int, str]:
-        """Fetch allowed vector keys from DuckDB (sync, runs in thread pool)."""
+        """Fetch allowed vector keys from DuckDB (sync, runs in thread pool).
+
+        Only the HNSW-matched ``candidate_keys`` are checked (inverted
+        filter): the query is bounded at O(k) rows instead of scanning
+        every vector_metadata row for the user.
+        """
+        if not candidate_keys:
+            return {}
+
         # Lifecycle states eligible for retrieval (exclude superseded/archived)
         _ACTIVE_STATES = ("tentative", "stable", "contested")
 
-        if scope is not None or time_from is not None or time_to is not None:
-            sql = (
-                "SELECT vm.vector_key, vm.node_id FROM vector_metadata vm "
-                "JOIN nodes n ON vm.node_id = n.id "
-                "WHERE vm.user_id = ?"
-                " AND COALESCE(n.lifecycle_state, 'tentative') IN (?, ?, ?)"
+        key_placeholders = ", ".join("?" for _ in candidate_keys)
+        sql = (
+            "SELECT vm.vector_key, vm.node_id FROM vector_metadata vm "
+            "JOIN nodes n ON vm.node_id = n.id "
+            f"WHERE vm.vector_key IN ({key_placeholders})"
+            " AND vm.user_id = ?"
+            " AND COALESCE(n.lifecycle_state, 'tentative') IN (?, ?, ?)"
+        )
+        params: list = [*candidate_keys, user_id, *_ACTIVE_STATES]
+
+        if scope is not None and scope:
+            placeholders = ", ".join("?" for _ in scope)
+            sql += f" AND n.scope IN ({placeholders})"
+            params.extend(scope)
+
+        if time_from is not None:
+            sql += (
+                " AND (n.valid_to IS NULL OR n.valid_to > ? "
+                "OR n.node_type IN ('ENTITY', 'PREFERENCE'))"
             )
-            params: list = [user_id, *_ACTIVE_STATES]
+            params.append(time_from)
 
-            if scope is not None and scope:
-                placeholders = ", ".join("?" for _ in scope)
-                sql += f" AND n.scope IN ({placeholders})"
-                params.extend(scope)
+        if time_to is not None:
+            sql += (
+                " AND (n.valid_from <= ? "
+                "OR n.node_type IN ('ENTITY', 'PREFERENCE'))"
+            )
+            params.append(time_to)
 
-            if time_from is not None:
-                sql += (
-                    " AND (n.valid_to IS NULL OR n.valid_to > ? "
-                    "OR n.node_type IN ('ENTITY', 'PREFERENCE'))"
-                )
-                params.append(time_from)
-
-            if time_to is not None:
-                sql += (
-                    " AND (n.valid_from <= ? "
-                    "OR n.node_type IN ('ENTITY', 'PREFERENCE'))"
-                )
-                params.append(time_to)
-
-            rows = self._conn.execute(sql, params).fetchall()
-            return {row[0]: row[1] for row in rows}
-        else:
-            rows = self._conn.execute(
-                "SELECT vm.vector_key, vm.node_id FROM vector_metadata vm "
-                "JOIN nodes n ON vm.node_id = n.id "
-                "WHERE vm.user_id = ?"
-                " AND COALESCE(n.lifecycle_state, 'tentative') IN (?, ?, ?)",
-                [user_id, *_ACTIVE_STATES],
-            ).fetchall()
-            return {row[0]: row[1] for row in rows}
+        rows = self._conn.execute(sql, params).fetchall()
+        return {row[0]: row[1] for row in rows}
 
     async def index(self, node_id: str, content: str, user_id: str) -> int:
         """Embed content and add to the vector index.
@@ -267,14 +269,22 @@ class VectorIndex:
 
         # Search USearch
         matches = self._index.search(query_vector, fetch_k)
+        matched_keys = [int(matches.keys[i]) for i in range(len(matches.keys))]
 
-        # Build set of allowed keys via DuckDB query with scope/temporal filtering.
-        # When scope or temporal filters are active, JOIN with nodes table.
-        # All DuckDB access is serialized through conn_lock to prevent
-        # concurrent thread access during asyncio.gather parallelism.
+        # Check only the matched keys against DuckDB (inverted filter:
+        # WHERE vector_key IN (...) bounded at fetch_k rows, instead of
+        # loading every vector_metadata row for the user). Scope/temporal
+        # filters JOIN with the nodes table. All DuckDB access is
+        # serialized through conn_lock to prevent concurrent thread
+        # access during asyncio.gather parallelism.
         async with self._conn_lock:
             allowed_keys = await asyncio.to_thread(
-                self._fetch_allowed_keys, user_id, scope, time_from, time_to
+                self._fetch_allowed_keys,
+                user_id,
+                scope,
+                time_from,
+                time_to,
+                matched_keys,
             )
 
         # Filter and map results

--- a/uv.lock
+++ b/uv.lock
@@ -2335,7 +2335,7 @@ wheels = [
 
 [[package]]
 name = "prme"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

The retrieval hot path was bottlenecked on DB round-trips and full-table scans, not on LLM or embedding cost (the audit's `memory_bank/audit-efficiency.md`). This lands the highest impact-per-effort items from #38:

- **Batch node resolution** — new `GraphStore.get_nodes(ids)` (`WHERE id IN (...)`), used in candidate resolution, the aggregation scan, and entity-focused retrieval, replacing up to ~1000 sequential `get_node()` calls per query.
- **Inverted vector-key filter** — `_fetch_allowed_keys` now checks only the HNSW-matched keys (`WHERE vector_key IN (...)`, bounded by over-fetch size) instead of loading every `vector_metadata` row for the user on each search.
- **SQL-side filters on `query_nodes`** — `scopes IN`, `session_ids IN`, `min_salience`, and `content_contains_any` (escaped `LOWER(content) LIKE`). Graph-seed discovery, pinned/active-task generation, and session-context expansion stop hydrating wide node windows and filtering in Python.
- **Single depth-aware neighborhood CTE** — `get_neighborhood_with_depth` returns `MIN(depth)` per node in one traversal (was one recursive query per hop level), plus a per-path cycle guard so `A->B->A` oscillation no longer enumerates exponentially many paths.
- **Concurrency / batching** — aggregation and entity-focused lexical searches run via `asyncio.gather`; CONTRADICTS edges for contested nodes are fetched in one batched query.
- **Cheaper cross-scope hint pass** — the secondary hint generation now skips the graph and pinned backends (it only needs vector + lexical).

## Behavior preservation

- Batch `get_nodes()` matches `get_node()`'s visibility semantics exactly (`lifecycle_state IN ('tentative','stable')` unless `include_superseded`), so CONTESTED handling downstream is unaffected.
- The new `salience >= 1.0` predicate reads the same stored `salience` column the old Python `node.salience == 1.0` compared.
- Neighborhood reachable set and minimum depths are unchanged; the cycle guard only removes revisiting paths, never the shortest path to a node.
- The pinned query intentionally now reaches eligible pinned/task nodes beyond the old newest-500 hydration window (the correctness twin noted in #38, overlaps #40).

## Testing

- `uv run pytest -q` → **1060 passed, 25 skipped** (the skips are PostgreSQL-only, no PG instance in this environment).
- `ruff check` clean on all changed files.

## Reviewer notes / risk

- The **PostgreSQL backend** changes (`pg/graph_store.py`: `get_nodes`, `get_neighborhood_with_depth`, `_NODE_COLUMNS_QUALIFIED`, `ANY($n::uuid[])` filters) mirror the DuckDB path structurally but are **not exercised by the passing suite** (those tests are skipped without a live PG). Worth a look if you run PG.
- `uv.lock` carries an incidental one-line sync: the local `prme` package version `0.8.0 → 0.9.0` (the lockfile was stale relative to the released 0.9.0).

Fixes #38