### PR TITLE
perf: batch the ingestion index write path (#39)

### DIFF
--- a/memory_bank/reviews/issue-39-ingestion-index-write-path-review.md
+++ b/memory_bank/reviews/issue-39-ingestion-index-write-path-review.md
@@ -1,0 +1,63 @@
+# Review — issue-39-ingestion-index-write-path
+
+## Files Changed
+- `src/prme/storage/vector_index.py` — debounced HNSW save; DuckDB+USearch writes moved off the event loop into `to_thread` under `conn_lock`; USearch search read serialized under `_write_lock` to avoid interleaving with a threaded save.
+- `src/prme/storage/lexical_index.py` — long-lived tantivy writer with count/time-batched commits; `flush()`; flush-on-search; writer released on `close()`.
+- `src/prme/ingestion/pipeline.py` — `asyncio.Semaphore` bounding concurrent background LLM extraction.
+- `src/prme/config.py` — 4 new config fields: `vector_save_interval`, `lexical_commit_interval`, `lexical_commit_max_delay_s`, `max_concurrent_extractions`.
+- `src/prme/storage/engine.py` — wires the new config into the DuckDB-path index/pipeline constructors and the Postgres-path pipeline.
+- `tests/test_index_write_path.py` — new tests for all of the above.
+
+## Approach Summary
+Addresses the highest impact-per-effort items from the June 2026 efficiency audit (issue #39: H2, H3, M4):
+- **H2** — full USearch index was saved to disk on every insert (O(N^2) write volume) and its writes ran synchronously on the event loop bypassing `conn_lock`. Now saves are debounced to `vector_save_interval` inserts (flushed on `close()`), and the DuckDB+USearch work runs in `to_thread` under `conn_lock`.
+- **H3** — tantivy created a fresh 50MB writer + commit + reload per document. Now a per-batch writer (created on the first add, released on commit) batches commits by count or elapsed time; the redundant post-index reload is gone; `search()` flushes pending docs first so it never misses its own writes. The writer holds tantivy's exclusive directory lock only while a batch is uncommitted, so other instances can still open the index path when idle.
+- **M4** — `ingest()` spawned one unbounded background extraction task per message. A semaphore now bounds concurrent extraction to `max_concurrent_extractions`.
+
+M3 (store write amplification), M5 (organizer cursors), and M6 (per-node organizer vector search) from the issue are larger algorithmic reworks that overlap a separate retrieval issue and the organizer correctness track; they are deliberately left for follow-up and noted on the PR.
+
+## Must Fix (resolved)
+| # | Finding | Resolution |
+|---|---------|------------|
+| 1 | New interleaving: index writes moved to a worker thread, but `search_by_vector` read the USearch index lock-free, so a concurrent full-index `save()` could overlap a search traversal. | Search read now runs under `_write_lock` in `to_thread` (`_search_index`/`_do_search_index`); it cannot interleave with `add`/`save`. |
+| 2 | Counter not reset on a failed save/commit → permanent per-insert retry storm. | `vector_index._do_index` resets `_unsaved_inserts` in a `finally`; `lexical_index._commit_locked` resets counters in a `finally`. Error still propagates. Covered by tests. |
+| 3 | Unused `do_save`/`did_save` return value (dead code). | `_do_index` now returns just `key`. |
+| 4 | No tests for new logic. | Added `tests/test_index_write_path.py` (10 tests): debounce save + flush-on-close, in-memory searchability, failed-save reset, lexical flush-on-search/interval/max-delay/close + reopen durability, failed-commit reset, semaphore bound. |
+| 5 | Long-lived tantivy writer holds an exclusive directory lock for the index lifetime. This broke any second `LexicalIndex` opened on the same path (caught by the full suite: 27 failures in `test_cli.py`/langchain where a CLI command opens its own engine alongside a live one). | Switched to a **per-batch writer**: created lazily on the first add of a batch and released (`wait_merging_threads()`) on every commit, so the directory lock is held only while a batch is uncommitted. Still one commit per batch; another instance can open the index when this one is idle. `close()` flushes (which commits + releases). |
+
+## Should Fix (resolved)
+| # | Finding | Resolution |
+|---|---------|------------|
+| 6 | Docstrings oversold `commit_max_delay_s` as a wall-clock timer. | Class/`index()` docstrings and the config description now state the bound is evaluated on the next index/search call (no background timer), and that `search()` always flushes first. |
+
+## Out of Scope (noted, not fixed here)
+| Finding | Why deferred |
+|---------|--------------|
+| Extraction timeout never enforced (`extraction.py` ignores `self._timeout`) — a hung LLM call holds a semaphore permit indefinitely and, with the new bound, can starve all ingestion. | Pre-existing bug in a file outside this change's scope; the semaphore makes it more visible but does not create it. Flagged on the PR as a follow-up so it gets its own change + tests. |
+| CI workflow triggers only on `master`; PRs into `main` skip CI. | Pre-existing CI config issue unrelated to this change; touching CI branch filters is out of scope. Noted on PR. |
+| No `.env.example` / docs enumerate the new config fields. | Fields are self-documented via `Field(description=...)`; mentioned in the PR body. No tracked env template exists to update. |
+
+## Security Audit Results
+| Area | Result | Details |
+|------|--------|---------|
+| Secrets/PII in logs | PASS | No new log lines; existing logs carry ids/counts only. |
+| Injection (SQL/cmd/path) | PASS | `_do_index` is a pure refactor of existing parameterized inserts; no new input reaches SQL/path. |
+| Config bounds | PASS | All new fields have `ge=` bounds; consumers also clamp with `max(...)`. |
+| Durability / data-loss | PASS | Vector/lexical indexes are rebuildable from the event log (source of truth). Graceful `close()` flushes both. Hard-crash window is bounded by interval and reconstructable. |
+| Availability (semaphore) | FAIL (pre-existing) | Extraction timeout unenforced — see Out of Scope. |
+
+## Pattern Consistency Assessment
+PASS. `_do_index` follows the established `async with conn_lock: await to_thread(_sync_fn)` pattern used by `event_store`/`duckpgq_graph`. New config fields match the top-level infra-knob style of `write_queue_size`/`materialization_queue_size` (correctly not `[HYPOTHESIS]`). `max_concurrent_extractions` is wired symmetrically into both the DuckDB and Postgres pipeline constructions; the index-batching args are correctly DuckDB-path only (Pg backends have native commit semantics).
+
+## Redundancy Check
+PASS. No existing debounce/batch/semaphore helper to reuse (`WriteQueue` handles ordering, not commit cadence). All 4 config fields are consumed. The dead `did_save` value was removed. The `_uncommitted` counter and `_oldest_uncommitted_at` timestamp are both needed (independent interval/time triggers).
+
+## Wiring Findings
+PASS. All 4 config fields defined with defaults and consumed in `engine.py`. `MemoryEngine.close()` drains the write queue before closing both indexes, so buffered/debounced writes flush in the right order. Existing index→search tests stay correct because `search()` auto-flushes. No test reads the indexes in a way that bypasses the flush.
+
+## Resolution Status
+| Severity | Count | Status |
+|----------|-------|--------|
+| Must Fix | 5 | All resolved |
+| Should Fix | 1 | Resolved |
+| Out of scope (noted) | 3 | Deferred / flagged on PR |

--- a/src/prme/config.py
+++ b/src/prme/config.py
@@ -378,6 +378,56 @@ class PRMEConfig(BaseSettings):
         ),
     )
 
+    # Index write-path batching (issue #39)
+    vector_save_interval: int = Field(
+        default=64,
+        ge=1,
+        description=(
+            "Number of vector inserts between full USearch index saves to "
+            "disk. The index is rewritten in full on each save, so saving on "
+            "every insert makes ingestion O(N^2) in write volume. Any "
+            "pending writes are always flushed on close(). Set to 1 to save "
+            "after every insert (legacy behavior)."
+        ),
+    )
+    lexical_commit_interval: int = Field(
+        default=64,
+        ge=1,
+        description=(
+            "Number of lexical documents added between tantivy commits. "
+            "Per-document commits cause segment explosion and merge churn. "
+            "Documents are buffered in a long-lived writer and committed "
+            "once this many are pending (or lexical_commit_max_delay_s "
+            "elapses). Pending documents are always committed on close(). "
+            "Set to 1 to commit after every document (legacy behavior). "
+            "Note: buffered documents are not searchable until committed."
+        ),
+    )
+    lexical_commit_max_delay_s: float = Field(
+        default=2.0,
+        ge=0.0,
+        description=(
+            "Maximum seconds a lexical document may sit uncommitted in the "
+            "writer buffer before a commit is forced, bounding search "
+            "staleness when fewer than lexical_commit_interval documents "
+            "arrive. The bound is evaluated when the next document is "
+            "indexed (there is no background timer); search() always "
+            "flushes pending writes first, so a query never misses its own "
+            "writes regardless of this value. 0 disables the time bound "
+            "(commit only on interval/search/close)."
+        ),
+    )
+    max_concurrent_extractions: int = Field(
+        default=8,
+        ge=1,
+        description=(
+            "Maximum number of concurrent background LLM extraction tasks "
+            "in the ingestion pipeline. Bounds memory and outbound LLM "
+            "request fan-out when ingesting large batches (ingest_batch of "
+            "N would otherwise launch N concurrent extractions)."
+        ),
+    )
+
     # Per-namespace weight profiles (issue #24)
     namespace_weights: dict[str, ScoringWeights] = Field(
         default_factory=dict,

--- a/src/prme/ingestion/pipeline.py
+++ b/src/prme/ingestion/pipeline.py
@@ -81,6 +81,7 @@ class IngestionPipeline:
         write_queue: WriteQueue,
         graph_writer: GraphWriter | None = None,
         confidence_matrix: object | None = None,
+        max_concurrent_extractions: int = 8,
     ) -> None:
         self._event_store = event_store
         self._graph_store = graph_store
@@ -89,6 +90,12 @@ class IngestionPipeline:
         self._extraction_provider = extraction_provider
         self._write_queue = write_queue
         self._graph_writer = graph_writer
+
+        # Bound concurrent background extraction tasks. Without this an
+        # ingest_batch of N launches N concurrent LLM calls (issue #39).
+        self._extraction_semaphore = asyncio.Semaphore(
+            max(1, max_concurrent_extractions)
+        )
 
         # Config-driven confidence matrix with module-level default fallback
         if confidence_matrix is not None:
@@ -228,9 +235,12 @@ class IngestionPipeline:
             scope: Ingestion-level scope for fallback when LLM does not classify.
         """
         try:
-            result = await self._extraction_provider.extract(
-                event.content, role=event.role
-            )
+            # Bound concurrent LLM extraction across all in-flight tasks
+            # so a large ingest_batch cannot fan out unbounded calls.
+            async with self._extraction_semaphore:
+                result = await self._extraction_provider.extract(
+                    event.content, role=event.role
+                )
             result = validate_grounding(result, event.content)
             await self._materialize(result, event, event_id, scope)
             logger.info(

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -234,10 +234,20 @@ class MemoryEngine:
         embedding_provider = create_embedding_provider(config.embedding)
 
         # Create vector index
-        vector_index = VectorIndex(conn, config.vector_path, embedding_provider, conn_lock)
+        vector_index = VectorIndex(
+            conn,
+            config.vector_path,
+            embedding_provider,
+            conn_lock,
+            save_interval=config.vector_save_interval,
+        )
 
         # Create lexical index
-        lexical_index = LexicalIndex(config.lexical_path)
+        lexical_index = LexicalIndex(
+            config.lexical_path,
+            commit_interval=config.lexical_commit_interval,
+            commit_max_delay_s=config.lexical_commit_max_delay_s,
+        )
 
         # Create and start write queue
         write_queue = WriteQueue(maxsize=config.write_queue_size)
@@ -266,6 +276,7 @@ class MemoryEngine:
             write_queue=write_queue,
             graph_writer=graph_writer,
             confidence_matrix=_active_confidence_matrix,
+            max_concurrent_extractions=config.max_concurrent_extractions,
         )
 
         from prme.retrieval.pipeline import RetrievalPipeline
@@ -372,6 +383,7 @@ class MemoryEngine:
             write_queue=write_queue,
             graph_writer=graph_writer,
             confidence_matrix=_active_confidence_matrix,
+            max_concurrent_extractions=config.max_concurrent_extractions,
         )
 
         from prme.retrieval.pipeline import RetrievalPipeline

--- a/src/prme/storage/lexical_index.py
+++ b/src/prme/storage/lexical_index.py
@@ -7,6 +7,7 @@ stemming and returns BM25-ranked results scoped by user_id.
 from __future__ import annotations
 
 import asyncio
+import time
 
 import tantivy
 
@@ -18,16 +19,42 @@ class LexicalIndex:
     language search. All queries are scoped by user_id using tantivy's
     query parser with field-specific terms.
 
-    Documents become searchable immediately after index() returns
-    (commit + reload are handled internally).
+    Writes are buffered in a per-batch writer and committed in batches.
+    The writer is created on the first add of a batch and released on the
+    commit, so the exclusive tantivy directory lock is held only while a
+    batch is uncommitted -- another instance can open the same index path
+    when this one is idle. A commit is triggered when ``commit_interval``
+    documents have accumulated, when ``commit_max_delay_s`` seconds have
+    elapsed since the oldest buffered document, when ``search()`` runs with
+    pending writes, or on ``close()``. The time bound is evaluated lazily on
+    the next
+    ``index()`` call (there is no background timer), so a lone buffered
+    document with no following writes stays uncommitted until the next
+    ``index()``/``search()``/``close()``. ``search()`` always flushes
+    pending writes first, so a query never misses its own writes.
+    Per-document commits cause tantivy segment explosion and merge churn,
+    so batching is the recommended pattern. Set ``commit_interval=1`` and
+    ``commit_max_delay_s=0`` for commit-per-document (legacy
+    immediate-searchability behavior).
 
     Args:
         index_path: Directory path for the persistent tantivy index.
+        commit_interval: Documents to buffer before committing (>=1).
+        commit_max_delay_s: Max seconds a document may stay uncommitted
+            before a commit is forced on the next index/search call. 0
+            disables the time bound.
     """
 
-    def __init__(self, index_path: str) -> None:
+    def __init__(
+        self,
+        index_path: str,
+        commit_interval: int = 64,
+        commit_max_delay_s: float = 2.0,
+    ) -> None:
         self._index_path = index_path
         self._write_lock = asyncio.Lock()
+        self._commit_interval = max(1, commit_interval)
+        self._commit_max_delay_s = max(0.0, commit_max_delay_s)
 
         # Build tantivy schema
         schema_builder = tantivy.SchemaBuilder()
@@ -51,6 +78,22 @@ class LexicalIndex:
         # Create or open persistent index
         self._index = tantivy.Index(self._schema, path=index_path)
 
+        # A writer is held only while a batch has uncommitted documents:
+        # created lazily on the first add of a batch and released on commit.
+        # This keeps one commit per batch (instead of per document) while
+        # NOT holding tantivy's exclusive directory lock between batches, so
+        # other readers/writers (e.g. a CLI engine on the same path) can
+        # open the index when this instance is idle.
+        self._writer: tantivy.IndexWriter | None = None
+        self._uncommitted = 0
+        self._oldest_uncommitted_at: float | None = None
+
+    def _ensure_writer(self) -> "tantivy.IndexWriter":
+        """Return the batch writer, creating it on the first add of a batch."""
+        if self._writer is None:
+            self._writer = self._index.writer(heap_size=50_000_000)
+        return self._writer
+
     def _do_index(
         self,
         node_id: str,
@@ -59,8 +102,12 @@ class LexicalIndex:
         node_type: str,
         scope: str | None,
     ) -> None:
-        """Synchronous indexing operation (runs in thread pool)."""
-        writer = self._index.writer(heap_size=50_000_000)
+        """Synchronous indexing operation (runs in thread pool).
+
+        Adds the document to the long-lived writer and commits only when
+        the batch interval or time delay threshold is reached.
+        """
+        writer = self._ensure_writer()
         doc_fields: dict = {
             "node_id": [node_id],
             "content": [content],
@@ -70,8 +117,45 @@ class LexicalIndex:
         if scope is not None:
             doc_fields["scope"] = [scope]
         writer.add_document(tantivy.Document(**doc_fields))
-        writer.commit()
-        self._index.reload()
+
+        self._uncommitted += 1
+        if self._oldest_uncommitted_at is None:
+            self._oldest_uncommitted_at = time.monotonic()
+
+        delay_exceeded = (
+            self._commit_max_delay_s > 0.0
+            and (time.monotonic() - self._oldest_uncommitted_at)
+            >= self._commit_max_delay_s
+        )
+        if self._uncommitted >= self._commit_interval or delay_exceeded:
+            self._commit_locked()
+
+    def _commit_locked(self) -> None:
+        """Commit buffered documents and reset the batch counters.
+
+        Must be called with ``_write_lock`` held (or before any concurrent
+        access). The post-commit ``reload`` makes committed docs visible to
+        new searchers; ``_do_search`` also reloads, so this keeps already
+        committed data current without an extra reload per add.
+        """
+        if self._uncommitted == 0 or self._writer is None:
+            return
+        # Reset the batch counters and release the writer in a finally so a
+        # failed commit does not re-trigger on every subsequent add (which
+        # would turn a transient failure into a per-document retry storm)
+        # and never leaks the exclusive directory lock. The error still
+        # propagates to the caller. wait_merging_threads consumes the writer
+        # and releases the directory lock; the next add recreates it.
+        try:
+            self._writer.commit()
+            self._index.reload()
+        finally:
+            self._uncommitted = 0
+            self._oldest_uncommitted_at = None
+            writer = self._writer
+            self._writer = None
+            if writer is not None:
+                writer.wait_merging_threads()
 
     async def index(
         self,
@@ -83,8 +167,12 @@ class LexicalIndex:
     ) -> None:
         """Index a document for full-text search.
 
-        The document becomes searchable immediately after this method
-        returns (commit + reload are handled internally).
+        The document is buffered and becomes searchable once the next
+        batch commit runs (on the commit interval, after the max delay is
+        observed on a later index call, on the next ``search`` call, or on
+        ``close``). Any ``search()`` flushes pending writes first, so a
+        query always sees documents indexed before it; for guaranteed
+        immediate visibility to other readers configure ``commit_interval=1``.
 
         Args:
             node_id: Unique identifier for the document.
@@ -98,6 +186,11 @@ class LexicalIndex:
             await asyncio.to_thread(
                 self._do_index, node_id, content, user_id, node_type, scope
             )
+
+    async def flush(self) -> None:
+        """Commit any buffered documents so they become searchable."""
+        async with self._write_lock:
+            await asyncio.to_thread(self._commit_locked)
 
     def _do_search(
         self,
@@ -186,6 +279,10 @@ class LexicalIndex:
             List of dicts with keys: node_id, content, score, node_type.
             Results are ordered by descending BM25 score.
         """
+        # Flush buffered writes so search reflects everything indexed so
+        # far (batched commits would otherwise hide recent documents).
+        if self._uncommitted > 0:
+            await self.flush()
         return await asyncio.to_thread(
             self._do_search, query_text, user_id, node_type, limit, scope
         )
@@ -210,10 +307,11 @@ class LexicalIndex:
         )
 
     async def close(self) -> None:
-        """Clean up resources.
+        """Flush buffered documents and release the writer.
 
-        tantivy-py handles cleanup automatically when the index
-        object is garbage collected. This method exists for API
-        consistency with other storage backends.
+        Commits any documents still buffered in the batch writer so no
+        indexed content is lost; the commit also releases the writer's
+        exclusive directory lock. A subsequent ``index()`` call
+        transparently recreates the writer.
         """
-        pass
+        await self.flush()

--- a/src/prme/storage/vector_index.py
+++ b/src/prme/storage/vector_index.py
@@ -45,12 +45,20 @@ class VectorIndex:
         index_path: str,
         embedding_provider: EmbeddingProvider,
         conn_lock: asyncio.Lock | None = None,
+        save_interval: int = 64,
     ) -> None:
         self._conn = conn
         self._index_path = index_path
         self._provider = embedding_provider
         self._write_lock = asyncio.Lock()
         self._conn_lock = conn_lock if conn_lock is not None else asyncio.Lock()
+
+        # Debounced save: the full USearch index file is rewritten on each
+        # save, so saving on every insert is O(N^2) total write volume.
+        # We save only once every ``save_interval`` inserts and flush any
+        # remaining pending writes on close(). Set to 1 for save-per-insert.
+        self._save_interval = max(1, save_interval)
+        self._unsaved_inserts = 0
 
         # Create metadata table and sequence in DuckDB
         self._init_metadata_table()
@@ -162,34 +170,67 @@ class VectorIndex:
         vector = np.array(embedding[0], dtype=np.float32)
 
         async with self._write_lock:
-            # Get next key from sequence
-            key = self._conn.execute(
-                "SELECT nextval('vector_key_seq')"
-            ).fetchone()[0]
+            # DuckDB + USearch writes are synchronous; run them off the
+            # event loop and serialize DuckDB access through conn_lock to
+            # match the other storage backends (event-loop blocking and
+            # thread-safety fix, issue #39). The full index save is
+            # debounced to avoid O(N^2) disk rewrites during ingestion.
+            async with self._conn_lock:
+                key = await asyncio.to_thread(
+                    self._do_index, node_id, content, user_id, vector
+                )
 
-            # Insert metadata
-            self._conn.execute(
-                """
-                INSERT INTO vector_metadata
-                    (vector_key, node_id, user_id, embedding_model,
-                     embedding_version, embedding_dim)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                [
-                    key,
-                    node_id,
-                    user_id,
-                    self._provider.model_name,
-                    self._provider.model_version,
-                    self._provider.dimension,
-                ],
-            )
+        return key
 
-            # Add to USearch index
-            self._index.add(key, vector)
+    def _do_index(
+        self,
+        node_id: str,
+        content: str,
+        user_id: str,
+        vector: np.ndarray,
+    ) -> int:
+        """Synchronous insert + (debounced) save (runs in thread pool).
 
-            # Persist to disk
-            self._index.save(self._index_path)
+        Returns the assigned vector key. Caller must hold both
+        ``_write_lock`` and ``_conn_lock``.
+        """
+        # Get next key from sequence
+        key = self._conn.execute(
+            "SELECT nextval('vector_key_seq')"
+        ).fetchone()[0]
+
+        # Insert metadata
+        self._conn.execute(
+            """
+            INSERT INTO vector_metadata
+                (vector_key, node_id, user_id, embedding_model,
+                 embedding_version, embedding_dim)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                key,
+                node_id,
+                user_id,
+                self._provider.model_name,
+                self._provider.model_version,
+                self._provider.dimension,
+            ],
+        )
+
+        # Add to USearch index
+        self._index.add(key, vector)
+
+        # Persist to disk on the debounce interval only. Remaining
+        # unsaved inserts are flushed by save()/close(). The counter is
+        # reset in a finally so a failed save does not re-trigger on every
+        # subsequent insert (the vector is already in the in-memory index
+        # and will be persisted by the next interval save or by close()).
+        self._unsaved_inserts += 1
+        if self._unsaved_inserts >= self._save_interval:
+            try:
+                self._index.save(self._index_path)
+            finally:
+                self._unsaved_inserts = 0
 
         return key
 
@@ -262,14 +303,14 @@ class VectorIndex:
         """
         query_vector = np.array(vector, dtype=np.float32)
 
-        # Over-fetch to compensate for post-filtering
-        fetch_k = min(k * self._OVERFETCH_FACTOR, len(self._index))
-        if fetch_k == 0:
+        # Run the USearch read under _write_lock and off the event loop.
+        # Index writes now happen in a worker thread (issue #39), so a
+        # concurrent full-index save() could otherwise interleave with a
+        # search traversal. The lock serializes the USearch index access;
+        # to_thread keeps the (CPU-bound) search off the event loop.
+        matched_keys = await self._search_index(query_vector, k)
+        if matched_keys is None:
             return []
-
-        # Search USearch
-        matches = self._index.search(query_vector, fetch_k)
-        matched_keys = [int(matches.keys[i]) for i in range(len(matches.keys))]
 
         # Check only the matched keys against DuckDB (inverted filter:
         # WHERE vector_key IN (...) bounded at fetch_k rows, instead of
@@ -277,6 +318,7 @@ class VectorIndex:
         # filters JOIN with the nodes table. All DuckDB access is
         # serialized through conn_lock to prevent concurrent thread
         # access during asyncio.gather parallelism.
+        candidate_keys = [key for key, _distance in matched_keys]
         async with self._conn_lock:
             allowed_keys = await asyncio.to_thread(
                 self._fetch_allowed_keys,
@@ -284,15 +326,12 @@ class VectorIndex:
                 scope,
                 time_from,
                 time_to,
-                matched_keys,
+                candidate_keys,
             )
 
         # Filter and map results
         results = []
-        for i in range(len(matches.keys)):
-            key = int(matches.keys[i])
-            distance = float(matches.distances[i])
-
+        for key, distance in matched_keys:
             if key not in allowed_keys:
                 continue
 
@@ -307,10 +346,43 @@ class VectorIndex:
 
         return results
 
-    async def save(self) -> None:
-        """Persist the USearch index to disk."""
+    async def _search_index(
+        self, query_vector: np.ndarray, k: int
+    ) -> list[tuple[int, float]] | None:
+        """Run the USearch nearest-neighbor read under the write lock.
+
+        Returns a list of ``(key, distance)`` tuples ordered by ascending
+        distance, or ``None`` when the index is empty. Held under
+        ``_write_lock`` and executed off the event loop so it cannot
+        interleave with a concurrent index ``add``/``save`` (issue #39).
+        """
         async with self._write_lock:
-            self._index.save(self._index_path)
+            return await asyncio.to_thread(self._do_search_index, query_vector, k)
+
+    def _do_search_index(
+        self, query_vector: np.ndarray, k: int
+    ) -> list[tuple[int, float]] | None:
+        """Synchronous USearch read (runs in thread pool under _write_lock)."""
+        # Over-fetch to compensate for post-filtering
+        fetch_k = min(k * self._OVERFETCH_FACTOR, len(self._index))
+        if fetch_k == 0:
+            return None
+
+        matches = self._index.search(query_vector, fetch_k)
+        return [
+            (int(matches.keys[i]), float(matches.distances[i]))
+            for i in range(len(matches.keys))
+        ]
+
+    async def save(self) -> None:
+        """Persist the USearch index to disk, flushing pending inserts.
+
+        Always writes the index regardless of the debounce counter, then
+        resets it. Runs off the event loop under the write lock.
+        """
+        async with self._write_lock:
+            await asyncio.to_thread(self._index.save, self._index_path)
+            self._unsaved_inserts = 0
 
     async def close(self) -> None:
         """Save index and clean up resources."""

--- a/tests/test_index_write_path.py
+++ b/tests/test_index_write_path.py
@@ -1,0 +1,345 @@
+"""Tests for the batched/debounced ingestion index write path (issue #39).
+
+Covers:
+- VectorIndex debounced HNSW save (save every N inserts, flush on close).
+- LexicalIndex batched tantivy commits, flush-on-search, flush-on-close.
+- Failure-safe counter reset so a failed save/commit does not retry-storm.
+- IngestionPipeline bounding concurrent LLM extraction with a semaphore.
+
+Uses mock providers and tmp_path for isolation; no LLM or model download.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import duckdb
+import pytest
+import pytest_asyncio
+
+from prme.ingestion.pipeline import IngestionPipeline
+from prme.ingestion.schema import ExtractionResult
+from prme.storage.duckpgq_graph import DuckPGQGraphStore
+from prme.storage.event_store import EventStore
+from prme.storage.lexical_index import LexicalIndex
+from prme.storage.schema import initialize_database
+from prme.storage.vector_index import VectorIndex
+from prme.storage.write_queue import WriteQueue
+
+
+# --- Mock providers -------------------------------------------------------
+
+
+class MockEmbeddingProvider:
+    """Deterministic mock embedding provider (8-dim)."""
+
+    @property
+    def model_name(self) -> str:
+        return "mock-embed"
+
+    @property
+    def model_version(self) -> str:
+        return "mock-1.0"
+
+    @property
+    def dimension(self) -> int:
+        return 8
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        out = []
+        for t in texts:
+            base = (hash(t) % 100) / 100.0
+            out.append([(base + j * 0.01) % 1.0 for j in range(8)])
+        return out
+
+
+# --- Fixtures -------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def conn(tmp_path: Path):
+    db_path = str(tmp_path / "test.duckdb")
+    c = duckdb.connect(db_path)
+    initialize_database(c)
+    yield c
+    c.close()
+
+
+# --- VectorIndex: debounced save -----------------------------------------
+
+
+async def test_vector_save_debounced_to_interval(tmp_path: Path, conn) -> None:
+    """The index file is written only once the save interval is reached."""
+    vector_path = tmp_path / "vectors.usearch"
+    vidx = VectorIndex(
+        conn, str(vector_path), MockEmbeddingProvider(), save_interval=3
+    )
+
+    # First two inserts must not write the file to disk.
+    await vidx.index("node-1", "alpha", "u1")
+    assert not vector_path.exists()
+    await vidx.index("node-2", "beta", "u1")
+    assert not vector_path.exists()
+
+    # The third insert hits the interval and persists.
+    await vidx.index("node-3", "gamma", "u1")
+    assert vector_path.exists()
+
+
+async def test_vector_close_flushes_pending_inserts(
+    tmp_path: Path, conn
+) -> None:
+    """close() persists inserts that have not yet hit the save interval."""
+    vector_path = tmp_path / "vectors.usearch"
+    vidx = VectorIndex(
+        conn, str(vector_path), MockEmbeddingProvider(), save_interval=100
+    )
+
+    await vidx.index("node-1", "alpha", "u1")
+    assert not vector_path.exists()  # below interval, not yet saved
+
+    await vidx.close()
+    assert vector_path.exists()  # flushed on close
+
+
+async def test_vector_search_after_index_sees_uncommitted_inserts(
+    tmp_path: Path, conn
+) -> None:
+    """In-memory adds are searchable before the debounced disk save."""
+    vector_path = tmp_path / "vectors.usearch"
+    vidx = VectorIndex(
+        conn, str(vector_path), MockEmbeddingProvider(), save_interval=100
+    )
+
+    # Insert a node and register it in the graph so the search JOIN matches.
+    await vidx.index("11111111-1111-1111-1111-111111111111", "hello world", "u1")
+    conn.execute(
+        """
+        INSERT INTO nodes (id, user_id, node_type, content, lifecycle_state,
+            scope, salience, confidence, created_at, updated_at)
+        VALUES (?, ?, 'EVENT', ?, 'tentative', 'PERSONAL', 0.5, 0.5,
+            current_timestamp, current_timestamp)
+        """,
+        ["11111111-1111-1111-1111-111111111111", "u1", "hello world"],
+    )
+
+    # Not yet saved to disk, but searchable from the in-memory index.
+    assert not vector_path.exists()
+    results = await vidx.search("hello world", "u1", k=5)
+    assert any(
+        r["node_id"] == "11111111-1111-1111-1111-111111111111" for r in results
+    )
+
+
+async def test_vector_failed_save_resets_counter(
+    tmp_path: Path, conn, monkeypatch
+) -> None:
+    """A save that raises does not leave the counter stuck (no retry storm)."""
+    vector_path = tmp_path / "vectors.usearch"
+    vidx = VectorIndex(
+        conn, str(vector_path), MockEmbeddingProvider(), save_interval=1
+    )
+
+    calls = {"n": 0}
+    real_save = vidx._index.save
+
+    def flaky_save(path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("disk full")
+        return real_save(path)
+
+    monkeypatch.setattr(vidx._index, "save", flaky_save)
+
+    # First insert triggers a save that raises; the error propagates.
+    with pytest.raises(OSError):
+        await vidx.index("node-1", "alpha", "u1")
+
+    # Counter was reset, so the next insert attempts a fresh save (not a
+    # stuck retry of the same failed state) and succeeds.
+    await vidx.index("node-2", "beta", "u1")
+    assert calls["n"] == 2
+    assert vidx._unsaved_inserts == 0
+
+
+# --- LexicalIndex: batched commits ---------------------------------------
+
+
+async def test_lexical_search_flushes_pending_docs(tmp_path: Path) -> None:
+    """A document indexed below the commit interval is found via search."""
+    lex_path = tmp_path / "lexical"
+    lex_path.mkdir()
+    lidx = LexicalIndex(
+        str(lex_path), commit_interval=100, commit_max_delay_s=0.0
+    )
+
+    await lidx.index("node-1", "the quick brown fox", "u1", "event", "PERSONAL")
+    # Buffered, not yet committed by interval -- but search must flush first.
+    results = await lidx.search("quick fox", "u1", limit=5)
+    assert any(r["node_id"] == "node-1" for r in results)
+
+
+async def test_lexical_commit_on_interval(tmp_path: Path) -> None:
+    """Reaching the commit interval makes docs visible without a flush."""
+    lex_path = tmp_path / "lexical"
+    lex_path.mkdir()
+    lidx = LexicalIndex(
+        str(lex_path), commit_interval=2, commit_max_delay_s=0.0
+    )
+
+    await lidx.index("node-1", "apple banana", "u1", "event", "PERSONAL")
+    assert lidx._uncommitted == 1  # buffered
+    await lidx.index("node-2", "cherry apple", "u1", "event", "PERSONAL")
+    assert lidx._uncommitted == 0  # interval reached -> committed
+
+
+async def test_lexical_close_flushes_buffered_docs(tmp_path: Path) -> None:
+    """close() commits documents still buffered in the long-lived writer."""
+    lex_path = tmp_path / "lexical"
+    lex_path.mkdir()
+    lidx = LexicalIndex(
+        str(lex_path), commit_interval=100, commit_max_delay_s=0.0
+    )
+    await lidx.index("node-1", "persisted content", "u1", "event", "PERSONAL")
+    assert lidx._uncommitted == 1
+    await lidx.close()
+    assert lidx._uncommitted == 0
+
+    # Reopen on the same path -- the committed doc is durable and searchable.
+    reopened = LexicalIndex(
+        str(lex_path), commit_interval=100, commit_max_delay_s=0.0
+    )
+    results = await reopened.search("persisted content", "u1", limit=5)
+    assert any(r["node_id"] == "node-1" for r in results)
+
+
+async def test_lexical_commit_on_max_delay(tmp_path: Path) -> None:
+    """A buffered doc commits when the time bound is observed on next index."""
+    lex_path = tmp_path / "lexical"
+    lex_path.mkdir()
+    lidx = LexicalIndex(
+        str(lex_path), commit_interval=1000, commit_max_delay_s=0.05
+    )
+
+    await lidx.index("node-1", "first doc", "u1", "event", "PERSONAL")
+    assert lidx._uncommitted == 1
+    await asyncio.sleep(0.06)
+    # The next index call observes the elapsed delay and forces a commit.
+    await lidx.index("node-2", "second doc", "u1", "event", "PERSONAL")
+    assert lidx._uncommitted == 0
+
+
+class _FlakyWriter:
+    """Wraps a tantivy writer; raises on the first commit, then delegates."""
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+        self.commit_calls = 0
+
+    def add_document(self, doc) -> None:
+        self._inner.add_document(doc)
+
+    def commit(self):
+        self.commit_calls += 1
+        if self.commit_calls == 1:
+            raise RuntimeError("commit boom")
+        return self._inner.commit()
+
+    def wait_merging_threads(self):
+        return self._inner.wait_merging_threads()
+
+
+async def test_lexical_failed_commit_resets_counter(tmp_path: Path) -> None:
+    """A commit that raises does not leave the counter stuck."""
+    lex_path = tmp_path / "lexical"
+    lex_path.mkdir()
+    lidx = LexicalIndex(
+        str(lex_path), commit_interval=1, commit_max_delay_s=0.0
+    )
+    # The batch writer is created lazily on first add; wrap it so the first
+    # commit raises. _ensure_writer returns the existing (wrapped) writer.
+    lidx._writer = _FlakyWriter(lidx._index.writer(heap_size=50_000_000))
+
+    with pytest.raises(RuntimeError):
+        await lidx.index("node-1", "alpha", "u1", "event", "PERSONAL")
+    # Counter reset despite the failure -> next add does not re-fire the
+    # same failed commit on top of a stuck count, and the writer was
+    # released (no leaked directory lock).
+    assert lidx._uncommitted == 0
+    assert lidx._writer is None
+
+
+# --- IngestionPipeline: bounded extraction concurrency -------------------
+
+
+class _GatedExtractionProvider:
+    """Extraction provider that tracks peak concurrency under a gate."""
+
+    def __init__(self, release: asyncio.Event) -> None:
+        self._release = release
+        self.active = 0
+        self.peak = 0
+
+    @property
+    def provider_name(self) -> str:
+        return "gated"
+
+    @property
+    def model_name(self) -> str:
+        return "gated-extract"
+
+    async def extract(self, content: str, *, role: str = "user"):
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        try:
+            await self._release.wait()
+        finally:
+            self.active -= 1
+        return ExtractionResult(
+            entities=[], facts=[], relationships=[], summary=None
+        )
+
+
+async def test_extraction_concurrency_is_bounded(tmp_path: Path, conn) -> None:
+    """ingest of N messages runs at most max_concurrent_extractions at once."""
+    from prme.ingestion.graph_writer import WriteQueueGraphWriter
+
+    conn_lock = asyncio.Lock()
+    event_store = EventStore(conn, conn_lock)
+    graph_store = DuckPGQGraphStore(conn, conn_lock)
+    vidx = VectorIndex(
+        conn, str(tmp_path / "v.usearch"), MockEmbeddingProvider(), conn_lock
+    )
+    lex_path = tmp_path / "lex"
+    lex_path.mkdir()
+    lidx = LexicalIndex(str(lex_path))
+    wq = WriteQueue(maxsize=1000)
+    await wq.start()
+
+    release = asyncio.Event()
+    provider = _GatedExtractionProvider(release)
+    pipeline = IngestionPipeline(
+        event_store=event_store,
+        graph_store=graph_store,
+        vector_index=vidx,
+        lexical_index=lidx,
+        extraction_provider=provider,
+        write_queue=wq,
+        graph_writer=WriteQueueGraphWriter(graph_store, wq),
+        max_concurrent_extractions=3,
+    )
+
+    # Launch more messages than the limit; none complete until released.
+    for i in range(10):
+        await pipeline.ingest(f"message {i}", user_id="u1")
+
+    # Let the gated extractions pile up against the semaphore.
+    await asyncio.sleep(0.1)
+    assert provider.peak <= 3
+    assert provider.active <= 3
+
+    release.set()
+    await pipeline.shutdown()
+    await wq.stop()
+    assert provider.peak <= 3


### PR DESCRIPTION
## Summary

- Debounce the USearch index save (save every `vector_save_interval` inserts, flush on close) and move the DuckDB + USearch writes off the event loop into a worker thread under `conn_lock`, removing the per-insert full-file rewrite (O(N^2) ingestion I/O) and the event-loop blocking / thread-safety gap.
- Replace the lexical index's per-document tantivy commit with a per-batch writer (commits on a count or time threshold, releases the directory lock on commit) and drop the redundant post-index reload; `search()` flushes pending writes first so it never misses its own writes.
- Bound concurrent background LLM extraction with an `asyncio.Semaphore` (`max_concurrent_extractions`, default 8) so `ingest_batch` of N no longer fans out to N concurrent extraction calls.

Adds four config knobs (`vector_save_interval`, `lexical_commit_interval`, `lexical_commit_max_delay_s`, `max_concurrent_extractions`); all preserve current behavior at the low end (set the intervals to 1 for per-insert/per-doc).

## Test plan

- [x] `uv run pytest -q` — full suite green (1070 passed, 25 skipped).
- [x] New `tests/test_index_write_path.py` covers: debounced vector save + flush-on-close, in-memory searchability before disk save, failure-safe counter reset, lexical flush-on-search / commit-on-interval / commit-on-max-delay / flush-on-close + reopen durability, failed-commit reset, and the extraction-concurrency cap.
- [x] `uv run ruff check` clean on all changed files.
- [x] Verified the per-batch writer releases tantivy's directory lock between batches, so a second engine/CLI can open the same index path (regression-tested against `test_cli.py` and the langchain integration tests).

## Notes for reviewers

- Scope: this addresses the H2/H3/M4 items of #39. M3 (store() vector-search amplification), M5 (organizer keyset cursors), and M6 (per-node organizer vector search) are larger algorithmic reworks that overlap the retrieval issue and the organizer correctness track — left for follow-up.
- Pre-existing, out of scope here but worth a follow-up: the extraction provider never enforces its configured timeout, so a hung extraction can hold a semaphore permit; and CI currently triggers only on `master`, so PRs into `main` skip the workflow.

Fixes #39