### PR TITLE
Productize multi-query reformulation as an opt-in retrieval mode (#43)

### DIFF
--- a/memory_bank/reviews/issue-43-productize-multi-query-reformulation-review.md
+++ b/memory_bank/reviews/issue-43-productize-multi-query-reformulation-review.md
@@ -1,0 +1,64 @@
+# Review — issue-43-productize-multi-query-reformulation
+
+## Files Changed
+
+- `src/prme/retrieval/reformulation.py` (NEW) — productized LLM multi-query reformulation module, mirroring `abstention.py`.
+- `src/prme/retrieval/pipeline.py` — new Stage 2.6 (opt-in), `_expand_reformulated_queries` helper, 4 new `__init__` params, docstring updates.
+- `src/prme/retrieval/__init__.py` — export `reformulate_query`.
+- `src/prme/config.py` — `enable_query_reformulation` (default False), `query_reformulation_count` (1-5, default 2).
+- `src/prme/storage/engine.py` — wire the 4 new params at both pipeline construction sites (DuckDB + PostgreSQL).
+
+## Approach Summary
+
+Move the benchmark-harness-only multi-query reformulation (`benchmarks/llm_judge.py`) into the product retrieval path as an opt-in mode (default OFF). When `enable_query_reformulation=True`, `retrieve()` asks the configured (extraction) LLM for N alternative phrasings, runs each through the same rule-based `analyze_query` + `generate_candidates` as the original query, and merges new candidates (deduped by node id) into the pool before scoring. With the flag off (default), `retrieve()` makes zero LLM calls — behavior unchanged. The product prompt is domain-neutral (no benchmark-specific examples), addressing the issue's no-benchmark-hacks requirement for the productized path.
+
+## Must Fix
+
+| # | Finding | Resolution |
+|---|---------|------------|
+| 1 | No tests for `reformulation.py` or the pipeline integration (Agents 3, 6). | RESOLVED — added `tests/test_reformulation.py`. |
+
+## Should Fix
+
+| # | Finding | Resolution |
+|---|---------|------------|
+| 2 | `retrieval_mode` not forwarded to `analyze_query` in the helper (Agent 1). | RESOLVED — threaded `retrieval_mode` through `_expand_reformulated_queries` to each alt-query `analyze_query`. |
+| 3 | Param naming `reformulation_provider`/`reformulation_model` inconsistent with the `query_reformulation_*` stem (Agent 3). | RESOLVED — renamed to `query_reformulation_provider`/`query_reformulation_model` in pipeline + both engine sites. |
+| 4 | Stale "6-stage"/"7-stage" docstrings; Stage 2.6 missing from module docstring (Agent 3). | RESOLVED — updated module/class/method docstrings and stage list. |
+| 5 | Redundant outer try/except around `reformulate_query` (callee never raises) (Agents 3, 5). | RESOLVED — removed; per-query errors now isolated via `asyncio.gather(return_exceptions=True)`. |
+
+## Consider
+
+| # | Finding | Resolution |
+|---|---------|------------|
+| 6 | Sequential alt-query retrieval vs the `asyncio.gather` convention used by sibling stages (Agents 3, 4). | RESOLVED — converted to `asyncio.gather` to match the aggregation-scan and entity-expansion stages. |
+| 7 | Export `reformulate_query` in `retrieval/__init__.py` for parity with `should_abstain` (Agent 6). | RESOLVED — exported. |
+| 8 | Extract shared `_get_client`/`_client_cache` (now duplicated across `abstention.py`/`reformulation.py`) (Agents 4, 5). | DEFERRED — pre-existing pattern; refactoring would touch `abstention.py` and make this module the odd one out. Tracked as a follow-up, not a gate. |
+| 9 | Harness `benchmarks/llm_judge.py` reformulation prompt still contains the `"X Sweden"` test-mirroring example; could delegate to the new product `reformulate_query` (Agents 4, 5). | DEFERRED — out of scope for this PR (product path only). Noted in PR body for follow-up. |
+| 10 | `query_reformulation_count` is `[HYPOTHESIS]`-tagged; consider an `experimental` config namespace before the v1.0 API freeze (Agent 6). | DEFERRED — broader config-API decision, not specific to this change. |
+
+## Security Audit Results
+
+| Area | Result | Details |
+|------|--------|---------|
+| Secrets/PII in logs | PASS | No raw query text logged at INFO/WARNING; alt-query logged only at DEBUG. |
+| Data egress gated by opt-in | PASS | Only LLM call reached via `enable_query_reformulation` (default False). Zero network calls on default path. |
+| Input validation / injection | PASS | Reformulated string flows to tantivy `parse_query_lenient` (structured parser) and parameterized SQL — no injection sink. |
+| Credentials in code/fixtures | PASS | No hardcoded keys; auth delegated to `instructor.from_provider` via provider env vars. |
+| Parity with `abstention.py` | PASS | Same cached-client + safe-fallback pattern, with extra input hardening. |
+
+## Pattern Consistency Assessment
+
+`reformulation.py` is a near-exact structural clone of `abstention.py` (client cache, prompt constant, pydantic model, keyword-only params, try/except-safe-default). Config fields match the `enable_reranker`/`reranker_*` cluster conventions (Field style, `[HYPOTHESIS]` tag, `ge/le` validation aligned with the runtime clamp). Both engine construction sites updated identically — no PG-mode silent-skip. Product prompt correctly diverges from the harness prompt to remove the benchmark-specific `"X Sweden"` example.
+
+## Redundancy Check
+
+No dead code. Config fields and all 4 pipeline params are wired through and used at both engine paths. The `reformulate_query`/`QueryReformulations`/prompt copy from `benchmarks/llm_judge.py` is justified (product code cannot import from `benchmarks/`, which is not in the installed wheel). The `_get_client`/`_client_cache` duplication is the established per-module pattern (also in `abstention.py`); extraction deferred as a follow-up.
+
+## Wiring Findings
+
+Config → engine (both sites) → pipeline `__init__` → `self._` attrs → use site chain is complete and verified. Provider/model sourced from `config.extraction.{provider,model}`. Default-off guarantee verified (zero LLM calls when flag is False). No new module registration required beyond the optional `__init__` export (added). New test file auto-collected by pytest (no `testpaths` restriction). No user-facing docs enumerate feature flags, so no doc update required by precedent.
+
+## Resolution Status
+
+All Must Fix and Should Fix findings resolved. Consider items either resolved or deferred with rationale (and surfaced in the PR body where cross-cutting).

--- a/src/prme/config.py
+++ b/src/prme/config.py
@@ -361,6 +361,29 @@ class PRMEConfig(BaseSettings):
         description="Number of top candidates to rerank (controls latency vs quality).",
     )
 
+    # Multi-query reformulation (issue #43)
+    enable_query_reformulation: bool = Field(
+        default=False,
+        description=(
+            "When True, retrieve() asks an LLM for alternative phrasings of "
+            "the query, runs each as an additional retrieval pass, and merges "
+            "the results (deduplicated by node id) with the original query's "
+            "results. Improves recall on tangential/keyword-mismatched facts "
+            "at the cost of one LLM call plus N extra retrievals per query. "
+            "Uses the extraction provider/model. Default False; with this off, "
+            "retrieve() makes no LLM calls (RFC-0005 S3)."
+        ),
+    )
+    query_reformulation_count: int = Field(
+        default=2,
+        ge=1,
+        le=5,
+        description=(
+            "Number of alternative queries to generate per retrieve() call "
+            "when enable_query_reformulation is True. [HYPOTHESIS]"
+        ),
+    )
+
     # Dual-stream ingestion (issue #25)
     materialization_queue_size: int = Field(
         default=500,

--- a/src/prme/retrieval/__init__.py
+++ b/src/prme/retrieval/__init__.py
@@ -25,6 +25,7 @@ from prme.retrieval.models import (
 )
 from prme.retrieval.packing import pack_context
 from prme.retrieval.pipeline import RetrievalPipeline
+from prme.retrieval.reformulation import reformulate_query
 from prme.retrieval.scoring import compute_composite_score, score_and_rank
 from prme.retrieval.snapshots import (
     EntitySnapshot,
@@ -53,6 +54,7 @@ __all__ = [
     "generate_all_entity_snapshots",
     "generate_entity_snapshot",
     "pack_context",
+    "reformulate_query",
     "render_snapshot_text",
     "score_and_rank",
     "should_abstain",

--- a/src/prme/retrieval/pipeline.py
+++ b/src/prme/retrieval/pipeline.py
@@ -1,9 +1,11 @@
-"""RetrievalPipeline orchestrator for the 7-stage hybrid retrieval pipeline.
+"""RetrievalPipeline orchestrator for the hybrid retrieval pipeline.
 
-Chains all seven stages in sequence:
+Chains the stages in sequence:
 1. Query Analysis (intent, entities, temporal signals)
 2. Candidate Generation (graph, vector, lexical, pinned -- parallel)
 3. Candidate Merging (deduplicate by node_id, track paths)
+2.5. Entity-Focused Expansion (per-entity lexical fan-out)
+2.6. Multi-Query Reformulation (opt-in LLM alt-query fan-out, issue #43)
 4. Epistemic Filtering (exclude HYPOTHETICAL/DEPRECATED in DEFAULT mode)
 5. Scoring + Ranking (8-input composite score, deterministic sort)
 5.5b. Session Context Expansion (pull adjacent turns from same session)
@@ -54,11 +56,12 @@ logger = logging.getLogger(__name__)
 
 
 class RetrievalPipeline:
-    """6-stage retrieval pipeline orchestrator.
+    """Hybrid retrieval pipeline orchestrator.
 
-    Chains query analysis, candidate generation, epistemic filtering,
-    scoring, context packing, and operation logging into a single
-    ``retrieve()`` call that returns a RetrievalResponse.
+    Chains query analysis, candidate generation, optional multi-query
+    reformulation, epistemic filtering, scoring, context packing, and
+    operation logging into a single ``retrieve()`` call that returns a
+    RetrievalResponse.
 
     All backend references and configuration are injected at construction.
     """
@@ -78,6 +81,10 @@ class RetrievalPipeline:
         enable_reranker: bool = False,
         reranker_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
         reranker_top_k: int = 100,
+        enable_query_reformulation: bool = False,
+        query_reformulation_count: int = 2,
+        query_reformulation_provider: str = "openai",
+        query_reformulation_model: str = "gpt-4o-mini",
     ) -> None:
         self._graph_store = graph_store
         self._vector_index = vector_index
@@ -90,6 +97,10 @@ class RetrievalPipeline:
         self._epistemic_weights = epistemic_weights
         self._unverified_confidence_threshold = unverified_confidence_threshold
         self._reranker_top_k = reranker_top_k
+        self._enable_query_reformulation = enable_query_reformulation
+        self._query_reformulation_count = query_reformulation_count
+        self._query_reformulation_provider = query_reformulation_provider
+        self._query_reformulation_model = query_reformulation_model
 
         # Lazy-init cross-encoder reranker when enabled.
         self._reranker = None
@@ -115,7 +126,7 @@ class RetrievalPipeline:
         retrieval_mode: RetrievalMode = RetrievalMode.DEFAULT,
         include_cross_scope: bool = True,
     ) -> RetrievalResponse:
-        """Execute the full 6-stage retrieval pipeline.
+        """Execute the full hybrid retrieval pipeline.
 
         This is the unified entry point for hybrid retrieval. Runs all
         stages in sequence and returns a RetrievalResponse with a packed
@@ -346,6 +357,25 @@ class RetrievalPipeline:
                         "Entity-focused node resolution failed; continuing",
                         exc_info=True,
                     )
+
+        # --- Stage 2.6: Multi-Query Reformulation (opt-in, issue #43) ---
+        # When enabled, ask an LLM for alternative phrasings of the query, run
+        # each as an additional candidate-generation pass, and merge the new
+        # hits (deduplicated by node id) into the candidate pool. Off by
+        # default: retrieve() makes no LLM calls unless this is configured.
+        if self._enable_query_reformulation:
+            reform_added = await self._expand_reformulated_queries(
+                query,
+                candidates=candidates,
+                user_id=user_id,
+                scope=normalized_scope,
+                time_from=effective_time_from,
+                time_to=effective_time_to,
+                retrieval_mode=analysis.retrieval_mode,
+                config=candidate_config,
+            )
+            if reform_added:
+                candidate_counts["REFORMULATION"] = reform_added
 
         # Track embedding mismatch from candidates module.
         # If VECTOR count is 0 but no explicit error, we check the flag
@@ -589,3 +619,91 @@ class RetrievalPipeline:
             filter_metadata=filter_meta,
             cross_scope_hints=cross_scope_hints,
         )
+
+    async def _expand_reformulated_queries(
+        self,
+        query: str,
+        *,
+        candidates: list[RetrievalCandidate],
+        user_id: str,
+        scope: list[Scope] | None,
+        time_from: datetime | None,
+        time_to: datetime | None,
+        retrieval_mode: RetrievalMode,
+        config: PackingConfig,
+    ) -> int:
+        """Run LLM-reformulated alternate queries and merge new candidates.
+
+        Asks the configured LLM for alternative phrasings of ``query``, runs
+        each through the same rule-based analysis + candidate generation as the
+        original, and appends candidates whose node id is not already present
+        in ``candidates`` (mutated in place). Each alternate query reuses the
+        original's effective scope, temporal window, and retrieval mode so
+        results stay comparable.
+
+        ``reformulate_query`` never raises (it returns an empty list on any
+        failure), and the per-query candidate-generation passes run via
+        ``asyncio.gather(..., return_exceptions=True)`` so a single failing
+        alternate query cannot break the others or the original retrieval --
+        on total failure no candidates are added and the original query's
+        results stand.
+
+        Returns:
+            The number of new candidates appended across all alternate queries.
+        """
+        from prme.retrieval.reformulation import reformulate_query
+
+        alt_queries = await reformulate_query(
+            query,
+            provider=self._query_reformulation_provider,
+            model=self._query_reformulation_model,
+            count=self._query_reformulation_count,
+        )
+        if not alt_queries:
+            return 0
+
+        # Fan out the alternate-query passes concurrently (matching the
+        # aggregation-scan and entity-expansion stages above), then merge.
+        async def _gen(alt_q: str) -> list[RetrievalCandidate]:
+            alt_analysis = await analyze_query(
+                alt_q,
+                time_from=time_from,
+                time_to=time_to,
+                retrieval_mode=retrieval_mode,
+            )
+            alt_candidates, _ = await generate_candidates(
+                alt_analysis,
+                graph_store=self._graph_store,
+                vector_index=self._vector_index,
+                lexical_index=self._lexical_index,
+                user_id=user_id,
+                scope=scope,
+                time_from=time_from,
+                time_to=time_to,
+                config=config,
+            )
+            return alt_candidates
+
+        results = await asyncio.gather(
+            *[_gen(alt_q) for alt_q in alt_queries],
+            return_exceptions=True,
+        )
+
+        existing_ids = {str(c.node.id) for c in candidates}
+        added = 0
+        for alt_q, alt_candidates in zip(alt_queries, results):
+            if isinstance(alt_candidates, BaseException):
+                logger.debug(
+                    "Reformulated query retrieval failed for %r; skipping",
+                    alt_q,
+                    exc_info=alt_candidates,
+                )
+                continue
+            for c in alt_candidates:
+                nid = str(c.node.id)
+                if nid in existing_ids:
+                    continue
+                existing_ids.add(nid)
+                candidates.append(c)
+                added += 1
+        return added

--- a/src/prme/retrieval/reformulation.py
+++ b/src/prme/retrieval/reformulation.py
@@ -1,0 +1,153 @@
+"""LLM-based multi-query reformulation for the retrieval pipeline.
+
+Stage 1 query analysis is rule-based and produces a single query per request
+(no blocking LLM calls, per RFC-0005 S3). For recall-sensitive workloads a
+single phrasing can miss facts that are only reachable under different keywords
+or from the perspective of the answer rather than the question.
+
+This module provides an *opt-in* reformulation step: given the original query
+it asks an LLM for a small number of alternative phrasings. The pipeline runs
+each alternative as an additional retrieval pass and merges the results,
+deduplicated by node id. It is off by default (``enable_query_reformulation``)
+because it adds one LLM call per ``retrieve()`` and requires a configured
+provider.
+
+This mirrors :mod:`prme.retrieval.abstention`: a self-contained module with a
+cached instructor client, provider/model parameters, and a safe fallback (an
+empty alternative list) when the provider is unconfigured or the call fails, so
+reformulation never breaks an otherwise-working retrieval.
+
+Usage::
+
+    from prme.retrieval.reformulation import reformulate_query
+
+    alternatives = await reformulate_query(
+        query, provider="openai", model="gpt-4o-mini", count=2
+    )
+    # alternatives is a list[str]; empty on failure -- caller falls back to
+    # the original query alone.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import instructor
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+REFORMULATION_SYSTEM_PROMPT = """\
+You are a search query reformulator. Given a question about a stored \
+conversation or knowledge history, generate alternative search queries that \
+would help find the relevant information.
+
+Rules:
+- Each reformulation should use different keywords and phrasing than the \
+original.
+- Focus on the key entities (people, places, things) and actions mentioned.
+- Include at least one simple keyword-style query (2-4 words).
+- Include at least one query phrased toward the likely ANSWER rather than the \
+question (e.g., for "Where did X move from?" try "X home country").
+- Keep each reformulation under 30 words.
+- Do not repeat the original question verbatim.\
+"""
+
+
+class QueryReformulations(BaseModel):
+    """Structured output for query reformulation."""
+
+    queries: list[str] = Field(
+        description="Alternative search queries",
+        default_factory=list,
+    )
+
+
+_client_cache: dict[str, instructor.AsyncInstructor] = {}
+
+
+def _get_client(provider_string: str) -> instructor.AsyncInstructor:
+    """Get or create a cached instructor async client."""
+    if provider_string not in _client_cache:
+        _client_cache[provider_string] = instructor.from_provider(
+            provider_string, async_client=True
+        )
+    return _client_cache[provider_string]
+
+
+async def reformulate_query(
+    query: str,
+    *,
+    provider: str = "openai",
+    model: str = "gpt-4o-mini",
+    count: int = 2,
+    max_retries: int = 2,
+) -> list[str]:
+    """Generate alternative search queries for improved recall.
+
+    Uses an LLM to produce ``count`` alternative phrasings of ``query``. The
+    pipeline runs each alternative as an additional retrieval pass and merges
+    the results (deduplicated by node id) with the original query's results.
+
+    Returns an empty list on any failure (unconfigured provider, network
+    error, validation error) so the caller can fall back to the original
+    query alone -- reformulation never breaks retrieval.
+
+    Args:
+        query: The original query text.
+        provider: LLM provider name (default: "openai").
+        model: LLM model name (default: "gpt-4o-mini").
+        count: Maximum number of alternative queries to return. Values are
+            clamped to ``[1, 5]``; the LLM may return fewer.
+        max_retries: Max retries on LLM schema-validation failure.
+
+    Returns:
+        A list of alternative query strings (at most ``count``). Empty on
+        failure. The original ``query`` is never included.
+    """
+    if not query or not query.strip():
+        return []
+
+    count = max(1, min(count, 5))
+    provider_string = f"{provider}/{model}"
+    try:
+        client = _get_client(provider_string)
+        result = await client.create(
+            response_model=QueryReformulations,
+            messages=[
+                {"role": "system", "content": REFORMULATION_SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": (
+                        f"Generate {count} alternative search queries.\n\n"
+                        f"Original question: {query}"
+                    ),
+                },
+            ],
+            max_retries=max_retries,
+        )
+    except Exception:
+        logger.warning(
+            "Query reformulation failed, falling back to original query only",
+            exc_info=True,
+        )
+        return []
+
+    # Drop blanks and any echo of the original query; cap at the request count.
+    original_norm = query.strip().casefold()
+    alternatives: list[str] = []
+    seen: set[str] = set()
+    for alt in result.queries:
+        if not isinstance(alt, str):
+            continue
+        candidate = alt.strip()
+        if not candidate:
+            continue
+        norm = candidate.casefold()
+        if norm == original_norm or norm in seen:
+            continue
+        seen.add(norm)
+        alternatives.append(candidate)
+        if len(alternatives) >= count:
+            break
+    return alternatives

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -294,6 +294,10 @@ class MemoryEngine:
             enable_reranker=config.enable_reranker,
             reranker_model=config.reranker_model,
             reranker_top_k=config.reranker_top_k,
+            enable_query_reformulation=config.enable_query_reformulation,
+            query_reformulation_count=config.query_reformulation_count,
+            query_reformulation_provider=config.extraction.provider,
+            query_reformulation_model=config.extraction.model,
         )
 
         # Run epistemic backfill migration for existing nodes
@@ -402,6 +406,10 @@ class MemoryEngine:
             enable_reranker=config.enable_reranker,
             reranker_model=config.reranker_model,
             reranker_top_k=config.reranker_top_k,
+            enable_query_reformulation=config.enable_query_reformulation,
+            query_reformulation_count=config.query_reformulation_count,
+            query_reformulation_provider=config.extraction.provider,
+            query_reformulation_model=config.extraction.model,
         )
 
         # Run epistemic backfill migration

--- a/tests/test_reformulation.py
+++ b/tests/test_reformulation.py
@@ -1,0 +1,200 @@
+"""Tests for opt-in LLM multi-query reformulation (issue #43).
+
+Covers two layers:
+
+1. The standalone ``prme.retrieval.reformulation.reformulate_query`` post-
+   processing: count clamping, blank/echo/dedup filtering, empty-query short
+   circuit, and the safe ``[]`` fallback when the LLM call fails.
+2. The pipeline integration: with ``enable_query_reformulation=False`` (the
+   default) retrieve() makes zero reformulation LLM calls; with it enabled and
+   reformulation stubbed, an alternate query surfaces a node the original
+   query misses and results are merged (deduplicated by node id).
+
+The LLM call is always mocked -- no network/provider access in tests.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import prme.retrieval.reformulation as reformulation
+from prme.client import MemoryClient, config_from_directory
+from prme.retrieval.reformulation import QueryReformulations, reformulate_query
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory(prefix="prme_reform_") as d:
+        yield d
+
+
+@pytest.fixture(autouse=True)
+def suppress_structlog():
+    """Suppress structlog output during tests."""
+    import sys
+
+    import structlog
+
+    structlog.configure(
+        processors=[structlog.dev.ConsoleRenderer()],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.CRITICAL),
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+    )
+
+
+def _mock_client_returning(queries: list[str]) -> AsyncMock:
+    """Build a mock instructor client whose create() yields ``queries``."""
+    client = AsyncMock()
+    client.create = AsyncMock(
+        return_value=QueryReformulations(queries=queries)
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# reformulate_query — post-processing
+# ---------------------------------------------------------------------------
+
+
+class TestReformulateQuery:
+    @pytest.mark.asyncio
+    async def test_returns_alternatives(self):
+        mock_client = _mock_client_returning(["alt one", "alt two"])
+        with patch.object(reformulation, "_get_client", return_value=mock_client):
+            result = await reformulate_query("original question", count=2)
+        assert result == ["alt one", "alt two"]
+
+    @pytest.mark.asyncio
+    async def test_empty_query_short_circuits(self):
+        # No client call should happen for blank input.
+        with patch.object(reformulation, "_get_client") as get_client:
+            assert await reformulate_query("") == []
+            assert await reformulate_query("   ") == []
+            get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drops_original_query_echo_case_insensitive(self):
+        mock_client = _mock_client_returning(
+            ["Original Question", "a genuine alternative"]
+        )
+        with patch.object(reformulation, "_get_client", return_value=mock_client):
+            result = await reformulate_query("original question", count=3)
+        assert result == ["a genuine alternative"]
+
+    @pytest.mark.asyncio
+    async def test_drops_blanks_and_intra_list_duplicates(self):
+        mock_client = _mock_client_returning(
+            ["dup", "  ", "DUP", "unique alt"]
+        )
+        with patch.object(reformulation, "_get_client", return_value=mock_client):
+            result = await reformulate_query("q", count=5)
+        assert result == ["dup", "unique alt"]
+
+    @pytest.mark.asyncio
+    async def test_caps_at_count(self):
+        mock_client = _mock_client_returning(["a", "b", "c", "d"])
+        with patch.object(reformulation, "_get_client", return_value=mock_client):
+            result = await reformulate_query("q", count=2)
+        assert result == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_count_clamped_to_valid_range(self):
+        # count=99 is clamped to 5; the mock supplies more than 5.
+        mock_client = _mock_client_returning(
+            ["a", "b", "c", "d", "e", "f", "g"]
+        )
+        with patch.object(reformulation, "_get_client", return_value=mock_client):
+            result = await reformulate_query("q", count=99)
+        assert len(result) == 5
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_string_items(self):
+        mock_client = AsyncMock()
+        # Bypass pydantic validation by returning a raw object with .queries.
+        mock_client.create = AsyncMock(
+            return_value=type("R", (), {"queries": ["ok", 42, None, "fine"]})()
+        )
+        with patch.object(reformulation, "_get_client", return_value=mock_client):
+            result = await reformulate_query("q", count=5)
+        assert result == ["ok", "fine"]
+
+    @pytest.mark.asyncio
+    async def test_failure_returns_empty_list(self):
+        mock_client = AsyncMock()
+        mock_client.create = AsyncMock(side_effect=RuntimeError("no api key"))
+        with patch.object(reformulation, "_get_client", return_value=mock_client):
+            result = await reformulate_query("q", count=2)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineIntegration:
+    def test_default_off_makes_no_reformulation_call(self, tmp_dir):
+        """With the flag off (default), no reformulation LLM call happens."""
+        with patch(
+            "prme.retrieval.reformulation.reformulate_query",
+            new_callable=AsyncMock,
+        ) as mock_reform:
+            with MemoryClient(tmp_dir) as client:
+                client.store("Alice likes dark mode", user_id="alice")
+                client.retrieve("preferences?", user_id="alice")
+            mock_reform.assert_not_called()
+
+    def test_enabled_merges_reformulated_candidates(self, tmp_dir):
+        """A reformulated alternate query surfaces a node missed otherwise."""
+        config = config_from_directory(tmp_dir)
+        config.enable_query_reformulation = True
+
+        # The alt query targets a distinctive keyword present only in the
+        # tangential fact, so it surfaces that node when reformulation runs.
+        async def fake_reformulate(query, **kwargs):
+            return ["aurochs"]
+
+        with patch(
+            "prme.retrieval.reformulation.reformulate_query",
+            side_effect=fake_reformulate,
+        ) as mock_reform:
+            with MemoryClient(config=config) as client:
+                client.store(
+                    "Last summer the team photographed an aurochs in the reserve",
+                    user_id="u1",
+                )
+                client.store("The quarterly budget review went smoothly", user_id="u1")
+
+                response = client.retrieve(
+                    "tell me about the budget meeting", user_id="u1"
+                )
+            mock_reform.assert_called()
+
+        contents = " ".join(r.node.content for r in response.results)
+        assert "aurochs" in contents, (
+            "reformulated query should surface the tangential node"
+        )
+
+    def test_enabled_dedupes_by_node_id(self, tmp_dir):
+        """Reformulated results that duplicate the original are not double-added."""
+        config = config_from_directory(tmp_dir)
+        config.enable_query_reformulation = True
+
+        async def fake_reformulate(query, **kwargs):
+            # Return a query that surfaces the SAME node as the original.
+            return ["dark mode preference"]
+
+        with patch(
+            "prme.retrieval.reformulation.reformulate_query",
+            side_effect=fake_reformulate,
+        ):
+            with MemoryClient(config=config) as client:
+                client.store("Alice likes dark mode", user_id="alice")
+                response = client.retrieve("dark mode", user_id="alice")
+
+        node_ids = [str(r.node.id) for r in response.results]
+        assert len(node_ids) == len(set(node_ids)), "duplicate nodes in results"


### PR DESCRIPTION
## Summary

- Moves LLM multi-query reformulation out of the benchmark harness and into the product retrieval pipeline as an **opt-in** mode (`enable_query_reformulation`, default **False**). This closes the audit's A1 gap where the headline LME/LoCoMo scores relied on harness-only machinery a `client.retrieve()` user could never reach.
- New `src/prme/retrieval/reformulation.py` mirrors the existing `abstention.py` pattern (cached instructor client, safe empty-list fallback). The reformulation prompt is **domain-neutral** — none of the benchmark-specific examples flagged in A2 (the "X Sweden" leak) are carried into the product path.
- When enabled, a new pipeline Stage 2.6 asks the configured (extraction) LLM for N alternate phrasings, runs each through the same rule-based analysis + candidate generation as the original query (concurrently, via `asyncio.gather`), and merges new candidates deduplicated by node id. Wired through both engine construction sites (DuckDB + PostgreSQL).

## Scope / what this PR does NOT do

This PR is intentionally bounded to the concrete code change (productizing reformulation + making it toggleable). It does **not** re-baseline the benchmarks — that requires a large number of gpt-5-mini API calls and is left for a separate, human-run measurement pass. Two follow-ups a maintainer should still pick up from the audit:

- **Re-baseline both benchmarks** on the product path (`enable_query_reformulation=True` via config) vs the current harness path, and treat any delta as previously-inflated headline score.
- The harness `benchmarks/llm_judge.py` reformulation prompt still contains the test-mirroring `"X Sweden"` example, and the harness still does its own entity fan-out / observation ingestion (A1 items 2-3). Those are out of scope here (product-path change only) and can be addressed separately — e.g. by having the harness delegate to `prme.retrieval.reformulate_query`, the way `check_abstention` already delegates to `should_abstain`.

A shared `_get_client`/`_client_cache` helper (now duplicated across `abstention.py` and `reformulation.py`) is also noted as a low-priority cleanup for a separate refactor.

## Test plan

- [x] `uv run pytest -q` — full suite green (1084 passed, 25 PostgreSQL skips).
- [x] New `tests/test_reformulation.py`: unit tests for count clamping, empty-query short-circuit, original-query echo + blank + case-insensitive dedup filtering, non-string handling, and the `[]`-on-failure fallback.
- [x] Integration test: with the flag **off** (default), `retrieve()` makes zero reformulation calls; with it **on** and reformulation stubbed, an alternate query surfaces an otherwise-missed node and results stay deduplicated by node id.
- [x] `ruff` clean on all changed files; `mypy` shows only a pre-existing `pool.acquire` typing note unrelated to this change.

To verify manually:
1. Default config: call `client.retrieve(...)` and confirm no LLM/network call occurs (behavior unchanged, no added latency or cost).
2. Set `enable_query_reformulation=True` with a configured extraction provider, then call `retrieve()` on a query whose answer is only reachable under different keywords, and confirm the tangential fact now appears in the results.

Fixes #43