### PR TITLE
security: harden encryption-at-rest lifecycle (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,19 @@ PRME_EMBEDDING_PROVIDER=fastembed      # fastembed (local, default) or openai
 PRME_EMBEDDING_MODEL_NAME=BAAI/bge-small-en-v1.5
 
 # Encryption at rest
-PRME_ENCRYPTION_KEY=your-secret-key    # Enables AES-128-CBC + HMAC encryption
+PRME_ENCRYPTION_ENABLED=true           # Master toggle (default false)
+PRME_ENCRYPTION_KEY=your-secret-key    # Passphrase (PBKDF2 -> Fernet AES-128-CBC + HMAC)
+# Optional explicit key type (avoids passphrase/raw-key ambiguity):
+#   PRME_ENCRYPTION_KEY=passphrase:your-secret-key   # always derive via PBKDF2
+#   PRME_ENCRYPTION_KEY=raw_key:<44-char-fernet-key> # use a raw Fernet key
 ```
+
+> **Plaintext window.** When the engine is open, pack files are decrypted to
+> plaintext on disk and are re-encrypted on a clean `close()` (an `atexit`
+> handler also re-encrypts on normal process exit as a best-effort safety
+> net). A hard crash (`SIGKILL`, power loss) can leave the pack plaintext on
+> disk until the next clean `close()`. Encryption secrets are held as
+> `SecretStr` so they are never rendered by config dumps or tracebacks.
 
 ## Testing
 

--- a/memory_bank/reviews/issue-37-encryption-robustness-hardening-review.md
+++ b/memory_bank/reviews/issue-37-encryption-robustness-hardening-review.md
@@ -1,0 +1,74 @@
+# Review — issue-37-encryption-robustness-hardening
+
+Issue #37: encryption robustness — fails open on close, crash leaves pack plaintext, key handling.
+
+## Files Changed
+
+- `src/prme/storage/encryption.py` — atomic write (temp + fsync + `os.replace`) for encrypt/decrypt; explicit `raw_key:`/`passphrase:` key-type prefixes with backward-compatible auto-detection retained; module docstring documents the plaintext window.
+- `src/prme/storage/engine.py` — `close()` fails closed (logs ERROR, re-raises `EncryptionError`) on encryption failure; best-effort `atexit` re-encrypt handler registered for DuckDB packs and unregistered on clean close; `SecretStr` consumers unwrapped via `.get_secret_value()`; `close()` docstring documents the new raise.
+- `src/prme/config.py` — `embedding.api_key`, `database_url`, `encryption_key` are now `pydantic.SecretStr | None`; `backend` property unwraps; `encryption_key` description documents the new prefixes.
+- `src/prme/storage/embedding.py` — unwraps the embedding `api_key` `SecretStr`.
+- `src/prme/client.py` — sync `MemoryClient.close()` propagates `EncryptionError` (fail closed through the sync facade) after completing loop/thread teardown.
+- `src/prme/cli.py` — `cmd_init` `.env.example` template documents `PRME_ENCRYPTION_ENABLED`.
+- `README.md` — documents the plaintext window, key-type prefixes, the master toggle, and SecretStr redaction.
+
+## Approach Summary
+
+Bounded, backward-compatible hardening of the encryption lifecycle:
+1. Fail closed on `close()` so a failed re-encryption is never silent.
+2. Atomic file writes so a crash never leaves a truncated/partial file; plaintext removed only after the ciphertext is durable.
+3. Best-effort `atexit` re-encrypt to narrow (not eliminate) the plaintext window on normal exits.
+4. Explicit key-type prefixes to remove passphrase/raw-key ambiguity, additive only — existing packs decrypt unchanged.
+5. `SecretStr` for the three secret fields so they are masked in dumps/reprs/tracebacks.
+
+Deliberately scoped OUT (flagged for a human): DuckDB native encryption (on-disk format change) and any change to the default key interpretation / KDF / on-disk format that could lock an existing user out of an already-encrypted pack.
+
+## Must Fix
+None.
+
+## Should Fix
+1. `MemoryClient.close()` swallowed the new `EncryptionError`, reintroducing fail-open through the sync facade. **Fixed** — it now re-raises after teardown; `_atexit_close` keeps swallowing (best-effort at exit); `__exit__`/`with` users get the fail-closed exception.
+2. Phase 5 tests for the new behavior. **Added** — see `tests/test_encryption.py`.
+3. `cmd_init` `.env.example` omitted `PRME_ENCRYPTION_ENABLED`, so the scaffold alone wouldn't enable encryption. **Fixed.**
+
+## Consider
+- `close()` docstring should document the new `EncryptionError` raise. **Done** (engine.py + client.py).
+- Idiom-alignment / one-line comment nits (Agent 4) — cosmetic, not applied to avoid churn.
+- Parent-directory fsync after `os.replace` for full rename durability — out of scope; file-content durability is the load-bearing guarantee and is in place.
+- Memory-pack files created at default umask (no explicit `0o600`) — pre-existing, out of scope for this issue.
+
+## Security Audit Results
+
+| Area | Result | Details |
+| --- | --- | --- |
+| SecretStr masking | PASS | Three secret fields masked in repr/str/model_dump; raw value only at 4 point-of-use call sites, never logged. |
+| Fail-open elimination | PASS | `close()` re-raises; sync `MemoryClient.close()` now propagates too; API lifespan propagates. |
+| Plaintext window not widened | PASS | Atomic temp is cleaned on failure; no lingering plaintext temp; encrypt temp holds ciphertext only. |
+| Key handling | PASS | PBKDF2 (600k iters), on-disk format, salt handling unchanged; explicit prefixes only remove guessing. |
+| Crash-safety ordering | PASS | Ciphertext durable (fsync) before plaintext unlink, and vice versa on decrypt. |
+| Temp/file permissions | N/A (informational) | Default umask; pre-existing, out of scope. |
+
+## Pattern Consistency Assessment
+- atexit lifecycle mirrors the existing `client.py` `_atexit_close` idiom (register guard, unregister on clean close, swallow+log), and is slightly stricter (explicit registration flag).
+- `_atomic_write` has no pre-existing analogue in the repo — justified local addition.
+- Three `SecretStr` conversions are uniform; `APIConfig.api_key` correctly left as plain `str` (compared via `secrets.compare_digest`, never serialized by PRME).
+
+## Redundancy Check
+No Remove/Replace/Consolidate actions warranted. New code (atomic write, key prefixes, atexit net, SecretStr wrapping) has no pre-existing equivalent. `import atexit` and `from prme.storage.encryption import EncryptionError` in engine.py are both new and used.
+
+## Wiring Findings
+- atexit registration reachable on the only provider-setting path (`_create_duckdb`); correctly absent for Postgres (no file pack).
+- `close()` re-raise propagates sanely: CLI surfaces it (`sys.exit(1)`), API lifespan surfaces it, sync client now propagates; atexit/`__del__` paths best-effort swallow.
+- pydantic-settings auto-coerces plain-string env vars / kwargs into `SecretStr` — no wiring change needed.
+- New `tests/test_encryption.py` cases auto-collected by CI (`uv run pytest tests/ -q`).
+
+## Resolution Status
+
+| Finding | Severity | Status |
+| --- | --- | --- |
+| `MemoryClient.close()` swallows EncryptionError (fail-open) | Should Fix | Resolved |
+| Phase 5 tests absent | Should Fix | Resolved |
+| `cmd_init` `.env.example` omits `PRME_ENCRYPTION_ENABLED` | Should Fix | Resolved |
+| `close()` docstring lacks `Raises: EncryptionError` | Consider | Resolved |
+| Idiom-alignment / comment nits | Consider | Not applied (cosmetic) |
+| Parent-dir fsync; explicit file mode | Consider | Out of scope (noted) |

--- a/src/prme/cli.py
+++ b/src/prme/cli.py
@@ -657,7 +657,8 @@ async def cmd_init(args: argparse.Namespace) -> None:
                 "# PRME_EMBEDDING__PROVIDER=fastembed\n"
                 "# PRME_EMBEDDING__MODEL_NAME=BAAI/bge-small-en-v1.5\n"
                 "\n"
-                "# Encryption at rest (optional)\n"
+                "# Encryption at rest (optional). Both are required to enable it.\n"
+                "# PRME_ENCRYPTION_ENABLED=true\n"
                 "# PRME_ENCRYPTION_KEY=your-secret-key\n"
             )
 

--- a/src/prme/client.py
+++ b/src/prme/client.py
@@ -278,7 +278,16 @@ class MemoryClient:
         )
 
     def close(self) -> None:
-        """Shut down the engine and background event loop."""
+        """Shut down the engine and background event loop.
+
+        Raises:
+            EncryptionError: If encryption-at-rest is enabled and the pack
+                could not be re-encrypted on close. The pack is plaintext on
+                disk in that case, so the failure is surfaced rather than
+                swallowed (fail closed). Loop and thread teardown still
+                completes before the error is raised. Other (non-encryption)
+                shutdown errors are logged and swallowed as best effort.
+        """
         if self._closed:
             return
         self._closed = True
@@ -288,18 +297,28 @@ class MemoryClient:
         except Exception:
             pass
 
-        # Close the engine on the background loop.
+        # Close the engine on the background loop. Capture an encryption
+        # failure so the pack-is-plaintext signal is not lost, but still
+        # finish tearing down the loop/thread before re-raising it.
+        from prme.storage.encryption import EncryptionError
+
+        encryption_error: EncryptionError | None = None
         try:
             future = asyncio.run_coroutine_threadsafe(
                 self._engine.close(), self._loop
             )
             future.result(timeout=30)
+        except EncryptionError as exc:
+            encryption_error = exc
         except Exception:
             logger.warning("Error closing engine", exc_info=True)
 
         # Stop the event loop and join the thread.
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout=5)
+
+        if encryption_error is not None:
+            raise encryption_error
 
     def __del__(self) -> None:
         if not self._closed:

--- a/src/prme/config.py
+++ b/src/prme/config.py
@@ -6,7 +6,7 @@ environment variables (PRME_ prefix), .env files, and direct arguments.
 
 from __future__ import annotations
 
-from pydantic import Field, model_validator
+from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings
 
 from prme.retrieval.config import PackingConfig, ScoringWeights
@@ -53,7 +53,7 @@ class EmbeddingConfig(BaseSettings):
     dimension: int = Field(
         default=384, description="Embedding vector dimension"
     )
-    api_key: str | None = Field(
+    api_key: SecretStr | None = Field(
         default=None,
         description="API key for API-based embedding providers (e.g., OpenAI)",
     )
@@ -234,7 +234,7 @@ class PRMEConfig(BaseSettings):
     double-underscore delimiter (e.g., PRME_EMBEDDING__DIMENSION=384).
     """
 
-    database_url: str | None = Field(
+    database_url: SecretStr | None = Field(
         default=None,
         description="PostgreSQL connection string. When set, all storage uses PostgreSQL.",
     )
@@ -506,12 +506,15 @@ class PRMEConfig(BaseSettings):
             "for backward compatibility."
         ),
     )
-    encryption_key: str | None = Field(
+    encryption_key: SecretStr | None = Field(
         default=None,
         description=(
-            "Encryption passphrase for at-rest encryption. "
-            "Used with PBKDF2-HMAC-SHA256 to derive a Fernet key. "
-            "None disables encryption regardless of encryption_enabled."
+            "Encryption passphrase (or raw key) for at-rest encryption. "
+            "Used with PBKDF2-HMAC-SHA256 to derive a Fernet key. Prefix "
+            "with 'raw_key:' to supply a raw Fernet key explicitly or "
+            "'passphrase:' to force derivation; an unprefixed value is "
+            "auto-detected for backward compatibility. None disables "
+            "encryption regardless of encryption_enabled."
         ),
     )
 
@@ -534,7 +537,8 @@ class PRMEConfig(BaseSettings):
     @property
     def backend(self) -> str:
         """Return 'postgres' when database_url is set, else 'duckdb'."""
-        return "postgres" if self.database_url else "duckdb"
+        url = self.database_url
+        return "postgres" if url and url.get_secret_value() else "duckdb"
 
     model_config = {
         "env_prefix": "PRME_",

--- a/src/prme/storage/embedding.py
+++ b/src/prme/storage/embedding.py
@@ -340,7 +340,11 @@ def create_embedding_provider(config: EmbeddingConfig) -> EmbeddingProvider:
     elif config.provider == "openai":
         provider = OpenAIEmbeddingProvider(
             model_name=config.model_name,
-            api_key=config.api_key,
+            api_key=(
+                config.api_key.get_secret_value()
+                if config.api_key is not None
+                else None
+            ),
             dimension=config.dimension,
         )
     else:

--- a/src/prme/storage/encryption.py
+++ b/src/prme/storage/encryption.py
@@ -13,6 +13,19 @@ Fernet tokens are self-contained (include IV/nonce and HMAC).
 Usage is transparent to the rest of PRME: files are decrypted on engine
 open and re-encrypted on engine close.
 
+Plaintext window (important)
+----------------------------
+Files are decrypted to plaintext on disk while the engine is open and are
+only re-encrypted on a clean ``close()`` / ``lock()``. The engine registers
+a best-effort ``atexit`` handler to re-encrypt on normal interpreter exit,
+but a hard crash (``SIGKILL``, power loss, OOM) leaves the pack plaintext on
+disk until the next clean ``close()`` re-encrypts it. File writes here are
+atomic (temp file + ``os.replace``) so a crash never leaves a truncated or
+partial file, but it cannot eliminate the plaintext-at-rest window itself.
+Eliminating that window entirely would require native database encryption
+(e.g. DuckDB ``ATTACH ... (ENCRYPTION_KEY ...)``); that is a separate,
+format-changing effort tracked apart from this lifecycle hardening.
+
 See RFC-0014 Section 10 for security requirements.
 """
 
@@ -48,11 +61,27 @@ class EncryptionProvider:
 
     Args:
         key: A Fernet key (bytes or base64 str) **or** a passphrase
-            string. If the value is exactly 44 characters of url-safe
-            base64 it is treated as a raw Fernet key; otherwise it is
-            treated as a passphrase and ``derive_key`` is called
-            on-demand with a per-file random salt.
+            string. Key-type resolution, first match wins:
+
+            1. ``bytes`` are always treated as a raw Fernet key.
+            2. A string with the ``raw_key:`` prefix is treated as a raw
+               Fernet key (the prefix is stripped). Use this to remove any
+               ambiguity for keys that look like passphrases, or to force
+               passphrases that happen to be valid base64 to be derived —
+               see point 4.
+            3. A string with the ``passphrase:`` prefix is always run
+               through PBKDF2, even if it is valid 44-char base64.
+            4. An unprefixed string is auto-detected: exactly 44 characters
+               of valid url-safe base64 (32 decoded bytes) is treated as a
+               raw Fernet key; anything else is treated as a passphrase.
+               This auto-detection is unchanged from prior releases and
+               remains the default so existing packs keep decrypting; the
+               explicit prefixes above are the recommended way to avoid the
+               ambiguity going forward.
     """
+
+    _RAW_KEY_PREFIX = "raw_key:"
+    _PASSPHRASE_PREFIX = "passphrase:"
 
     def __init__(self, key: bytes | str | None = None) -> None:
         if key is None:
@@ -65,15 +94,24 @@ class EncryptionProvider:
             # Raw Fernet key
             self._fernet_key = key
         elif isinstance(key, str):
-            # Try to interpret as base64 Fernet key (exactly 44 chars)
-            try:
-                decoded = base64.urlsafe_b64decode(key)
-                if len(decoded) == 32 and len(key) == 44:
-                    self._fernet_key = key.encode("ascii")
-                else:
+            if key.startswith(self._RAW_KEY_PREFIX):
+                # Explicit raw key -- no derivation, no guessing.
+                self._fernet_key = key[len(self._RAW_KEY_PREFIX):].encode("ascii")
+            elif key.startswith(self._PASSPHRASE_PREFIX):
+                # Explicit passphrase -- always derive, even if it is base64.
+                self._passphrase = key[len(self._PASSPHRASE_PREFIX):]
+            else:
+                # Backward-compatible auto-detection: a 44-char valid
+                # url-safe base64 string (32 decoded bytes) is a raw Fernet
+                # key; otherwise it is a passphrase.
+                try:
+                    decoded = base64.urlsafe_b64decode(key)
+                    if len(decoded) == 32 and len(key) == 44:
+                        self._fernet_key = key.encode("ascii")
+                    else:
+                        self._passphrase = key
+                except Exception:
                     self._passphrase = key
-            except Exception:
-                self._passphrase = key
 
     @staticmethod
     def derive_key(passphrase: str, salt: bytes | None = None) -> tuple[bytes, bytes]:
@@ -122,11 +160,43 @@ class EncryptionProvider:
         fernet_key, salt = self.derive_key(self._passphrase, existing_salt)
         return Fernet(fernet_key), salt
 
+    @staticmethod
+    def _atomic_write(target: Path, data: bytes) -> None:
+        """Write ``data`` to ``target`` atomically (temp file + fsync + rename).
+
+        Writes to a sibling temp file, flushes it to disk, then renames it
+        over ``target``. ``os.replace`` is atomic on the same filesystem, so
+        a crash mid-write never leaves a partial or truncated file at
+        ``target`` -- a reader sees either the old contents (if the rename
+        had not happened) or the complete new contents, never a half-written
+        mix.
+
+        Args:
+            target: Final destination path.
+            data: Bytes to write.
+        """
+        tmp = target.with_name(f".{target.name}.tmp-{os.getpid()}")
+        try:
+            with open(tmp, "wb") as fh:
+                fh.write(data)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, target)
+        except Exception:
+            # Never leave a stray temp file behind on failure.
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise
+
     def encrypt_file(self, path: Path) -> Path:
         """Encrypt a file in-place, producing a ``.enc`` file.
 
-        The original unencrypted file is removed after successful
-        encryption. File format: ``[16-byte salt][Fernet token]``.
+        The original unencrypted file is removed only after the encrypted
+        file is fully and durably written, so a crash during encryption can
+        never destroy the plaintext without leaving a complete ciphertext.
+        File format: ``[16-byte salt][Fernet token]``.
 
         Args:
             path: Path to the plaintext file.
@@ -152,9 +222,12 @@ class EncryptionProvider:
             ciphertext = fernet.encrypt(plaintext)
 
             enc_path = path.with_suffix(path.suffix + _ENC_EXTENSION)
-            enc_path.write_bytes(salt + ciphertext)
+            # Atomic write: the ciphertext is fully durable on disk before
+            # the plaintext is removed. A crash leaves the plaintext intact
+            # (recoverable) rather than a truncated/partial .enc file.
+            self._atomic_write(enc_path, salt + ciphertext)
 
-            # Remove original after successful write
+            # Remove original only after the encrypted file is durable.
             path.unlink()
             logger.debug("Encrypted %s -> %s", path, enc_path)
             return enc_path
@@ -198,9 +271,12 @@ class EncryptionProvider:
 
             # Restore original path (strip .enc suffix)
             dec_path = path.with_suffix("")
-            dec_path.write_bytes(plaintext)
+            # Atomic write: the plaintext is fully durable before the .enc
+            # file is removed, so a crash mid-decrypt leaves the encrypted
+            # file intact rather than a truncated plaintext.
+            self._atomic_write(dec_path, plaintext)
 
-            # Remove encrypted file after successful write
+            # Remove encrypted file only after the plaintext is durable.
             path.unlink()
             logger.debug("Decrypted %s -> %s", path, dec_path)
             return dec_path

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -21,6 +21,7 @@ error handling, and lifecycle transitions are managed here.
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import warnings
 from contextlib import asynccontextmanager
@@ -36,6 +37,7 @@ from prme.quality.metrics import QualityMetrics, compute_quality_metrics
 from prme.quality.tuner import WeightTuner
 from prme.storage.duckpgq_graph import DuckPGQGraphStore
 from prme.storage.embedding import create_embedding_provider
+from prme.storage.encryption import EncryptionError
 from prme.storage.event_store import EventStore
 from prme.storage.lexical_index import LexicalIndex
 from prme.storage.schema import initialize_database
@@ -115,6 +117,9 @@ class MemoryEngine:
         # Encryption at rest (issue #14)
         from prme.storage.encryption import EncryptionProvider
         self._encryption_provider: EncryptionProvider | None = None
+        # Best-effort atexit re-encryption guard (issue #37). Registered in
+        # the create() classmethods once an encryption provider exists.
+        self._atexit_registered = False
 
         # Quality assessment and auto-tuning (issue #24)
         self._feedback_tracker = FeedbackTracker()
@@ -192,8 +197,14 @@ class MemoryEngine:
 
         # --- Decrypt memory pack if encryption is enabled (issue #14) ---
         encryption_provider: EncryptionProvider | None = None
-        if config.encryption_enabled and config.encryption_key:
-            encryption_provider = EncryptionProvider(config.encryption_key)
+        if (
+            config.encryption_enabled
+            and config.encryption_key
+            and config.encryption_key.get_secret_value()
+        ):
+            encryption_provider = EncryptionProvider(
+                config.encryption_key.get_secret_value()
+            )
 
             # Decrypt DuckDB file if encrypted version exists
             db_enc = Path(config.db_path + ".enc")
@@ -333,6 +344,7 @@ class MemoryEngine:
         )
         engine._encryption_provider = encryption_provider
         engine._maintenance_runner = MaintenanceRunner(engine, config.organizer)
+        engine._register_atexit_encrypt()
         return engine
 
     @classmethod
@@ -350,7 +362,7 @@ class MemoryEngine:
         assert config.database_url is not None
 
         # Create asyncpg pool and initialize schema
-        pool = await create_pool(config.database_url)
+        pool = await create_pool(config.database_url.get_secret_value())
         await initialize_pg_database(pool, embedding_dim=config.embedding.dimension)
 
         # Create Pg backends
@@ -1853,6 +1865,15 @@ class MemoryEngine:
         the LexicalIndex, and closes the DuckDB connection.
 
         Idempotent — safe to call multiple times.
+
+        When encryption at rest is enabled, the memory pack is re-encrypted
+        after all backends are closed. If that encryption fails the pack is
+        left plaintext on disk, so this method fails closed: it logs at ERROR
+        and raises ``EncryptionError`` rather than returning silently (issue
+        #37).
+
+        Raises:
+            EncryptionError: If re-encrypting the memory pack on close fails.
         """
         if self._closed:
             return
@@ -1894,15 +1915,69 @@ class MemoryEngine:
                 logger.warning("Error closing PostgreSQL pool", exc_info=True)
 
         # --- Encrypt memory pack after all backends are closed (issue #14) ---
+        # Fail closed: if encryption fails the pack is plaintext on disk, so
+        # the caller MUST be told rather than silently shipping plaintext
+        # (issue #37). The backends are already closed at this point, so
+        # re-raising here only surfaces the encryption failure; it does not
+        # leak resources.
         if self._encryption_provider is not None and self._config is not None:
+            # close() encrypts authoritatively, so drop the best-effort
+            # atexit net to avoid a redundant second pass at exit.
+            if self._atexit_registered:
+                atexit.unregister(self._atexit_encrypt)
+                self._atexit_registered = False
             try:
                 self._encrypt_memory_pack()
-            except Exception:
-                logger.warning(
-                    "Error encrypting memory pack on close", exc_info=True
+            except Exception as exc:
+                logger.error(
+                    "Failed to encrypt memory pack on close; pack remains "
+                    "PLAINTEXT on disk at %s",
+                    self._config.db_path,
+                    exc_info=True,
                 )
+                raise EncryptionError(
+                    "Failed to encrypt memory pack on close; the pack is "
+                    "plaintext on disk. See logs for the underlying error."
+                ) from exc
 
     # --- Encryption at rest helpers (issue #14) ---
+
+    def _register_atexit_encrypt(self) -> None:
+        """Register a best-effort atexit handler to re-encrypt on exit.
+
+        This is a safety net for the plaintext-on-disk window (issue #37):
+        if the process exits normally without a clean ``close()``, the pack
+        is still re-encrypted. It is *best effort only* — a hard crash
+        (``SIGKILL``, power loss) bypasses ``atexit`` entirely, and if the
+        backends still hold the DuckDB file lock the re-encryption may fail.
+        The authoritative path remains an explicit ``await close()``.
+        """
+        if self._encryption_provider is None or self._atexit_registered:
+            return
+        atexit.register(self._atexit_encrypt)
+        self._atexit_registered = True
+
+    def _atexit_encrypt(self) -> None:
+        """Best-effort synchronous re-encryption on interpreter exit.
+
+        Swallows all errors: at interpreter shutdown there is no caller to
+        propagate to, and a failure here is no worse than the pre-existing
+        plaintext-on-disk state. Errors are logged so the window is visible.
+        """
+        if self._closed or self._encryption_provider is None:
+            return
+        try:
+            self._encrypt_memory_pack()
+            logger.warning(
+                "Re-encrypted memory pack via atexit handler; the engine was "
+                "not closed cleanly. Prefer an explicit close()."
+            )
+        except Exception:
+            logger.error(
+                "atexit re-encryption failed; memory pack may remain "
+                "plaintext on disk",
+                exc_info=True,
+            )
 
     def _encrypt_memory_pack(self) -> None:
         """Encrypt all memory pack files after backends are closed.

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -14,13 +14,11 @@ Validates:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import tempfile
 from pathlib import Path
 
 import pytest
-import pytest_asyncio
 
 from prme.storage.encryption import (
     EncryptionError,
@@ -482,3 +480,247 @@ class TestLockUnlock:
         with pytest.raises(RuntimeError, match="encryption is not configured"):
             engine.unlock()
         await engine.close()
+
+
+# ---------------------------------------------------------------------------
+# Atomic writes (issue #37)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWrite:
+    """encrypt_file / decrypt_file write atomically (temp + os.replace)."""
+
+    def test_encrypt_leaves_no_temp_file_on_success(self, provider, tmp_dir):
+        f = tmp_dir / "payload.txt"
+        f.write_text("plaintext payload")
+        enc = provider.encrypt_file(f)
+        # No stray temp file, plaintext gone, ciphertext present.
+        leftovers = [c.name for c in tmp_dir.iterdir() if ".tmp-" in c.name]
+        assert leftovers == []
+        assert enc.exists()
+        assert not f.exists()
+
+    def test_decrypt_leaves_no_temp_file_on_success(self, provider, tmp_dir):
+        f = tmp_dir / "payload.txt"
+        f.write_text("plaintext payload")
+        enc = provider.encrypt_file(f)
+        dec = provider.decrypt_file(enc)
+        leftovers = [c.name for c in tmp_dir.iterdir() if ".tmp-" in c.name]
+        assert leftovers == []
+        assert dec.read_text() == "plaintext payload"
+        assert not enc.exists()
+
+    def test_encrypt_failure_preserves_plaintext_and_cleans_temp(
+        self, provider, tmp_dir, monkeypatch
+    ):
+        """If the atomic rename fails, plaintext survives and no temp lingers."""
+        f = tmp_dir / "payload.txt"
+        f.write_text("important plaintext")
+
+        def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("os.replace", boom)
+        with pytest.raises(EncryptionError):
+            provider.encrypt_file(f)
+
+        # Plaintext is still intact (never destroyed), and no temp remains.
+        assert f.exists()
+        assert f.read_text() == "important plaintext"
+        leftovers = [c.name for c in tmp_dir.iterdir() if ".tmp-" in c.name]
+        assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# Explicit key-type prefixes (issue #37)
+# ---------------------------------------------------------------------------
+
+
+class TestKeyTypePrefixes:
+    """raw_key: / passphrase: prefixes disambiguate key handling."""
+
+    def test_raw_key_prefix_uses_raw_fernet_key(self):
+        from cryptography.fernet import Fernet
+
+        raw = Fernet.generate_key().decode("ascii")
+        p = EncryptionProvider("raw_key:" + raw)
+        assert p._fernet_key == raw.encode("ascii")
+        assert p._passphrase is None
+
+    def test_passphrase_prefix_forces_derivation_on_base64(self):
+        """A 44-char base64 value with passphrase: prefix is derived, not raw."""
+        from cryptography.fernet import Fernet
+
+        looks_like_key = Fernet.generate_key().decode("ascii")
+        assert len(looks_like_key) == 44  # would auto-detect as raw without prefix
+        p = EncryptionProvider("passphrase:" + looks_like_key)
+        assert p._passphrase == looks_like_key
+        assert p._fernet_key is None
+
+    def test_unprefixed_autodetect_unchanged_raw(self):
+        from cryptography.fernet import Fernet
+
+        raw = Fernet.generate_key().decode("ascii")
+        p = EncryptionProvider(raw)
+        assert p._fernet_key == raw.encode("ascii")
+        assert p._passphrase is None
+
+    def test_unprefixed_autodetect_unchanged_passphrase(self):
+        p = EncryptionProvider("a-normal-human-passphrase")
+        assert p._passphrase == "a-normal-human-passphrase"
+        assert p._fernet_key is None
+
+    def test_raw_key_prefix_roundtrip(self, sample_file):
+        from cryptography.fernet import Fernet
+
+        raw = Fernet.generate_key().decode("ascii")
+        original = sample_file.read_text()
+        enc = EncryptionProvider("raw_key:" + raw).encrypt_file(sample_file)
+        dec = EncryptionProvider("raw_key:" + raw).decrypt_file(enc)
+        assert dec.read_text() == original
+
+    def test_passphrase_prefix_roundtrip(self, sample_file):
+        original = sample_file.read_text()
+        enc = EncryptionProvider("passphrase:secret").encrypt_file(sample_file)
+        dec = EncryptionProvider("passphrase:secret").decrypt_file(enc)
+        assert dec.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# SecretStr config fields (issue #37)
+# ---------------------------------------------------------------------------
+
+
+class TestSecretConfigFields:
+    """The three secret config fields are SecretStr and never leak."""
+
+    def test_encryption_key_is_secret_and_masked(self):
+        from pydantic import SecretStr
+
+        from prme.config import PRMEConfig
+
+        c = PRMEConfig(encryption_enabled=True, encryption_key="topsecret")
+        assert isinstance(c.encryption_key, SecretStr)
+        assert c.encryption_key.get_secret_value() == "topsecret"
+        # Secret must not appear in repr or model_dump string form.
+        assert "topsecret" not in repr(c.encryption_key)
+        assert "topsecret" not in str(c)
+        assert "topsecret" not in str(c.model_dump())
+
+    def test_database_url_is_secret(self):
+        from pydantic import SecretStr
+
+        from prme.config import PRMEConfig
+
+        c = PRMEConfig(database_url="postgresql://u:p@host/db")
+        assert isinstance(c.database_url, SecretStr)
+        assert c.database_url.get_secret_value() == "postgresql://u:p@host/db"
+        assert "p@host" not in repr(c.database_url)
+
+    def test_embedding_api_key_is_secret(self):
+        from pydantic import SecretStr
+
+        from prme.config import EmbeddingConfig
+
+        c = EmbeddingConfig(api_key="sk-secret")
+        assert isinstance(c.api_key, SecretStr)
+        assert c.api_key.get_secret_value() == "sk-secret"
+        assert "sk-secret" not in repr(c)
+
+    def test_backend_property_with_secret_url(self):
+        from prme.config import PRMEConfig
+
+        assert PRMEConfig(database_url="postgresql://localhost/db").backend == "postgres"
+        assert PRMEConfig(database_url=None).backend == "duckdb"
+        # Empty url string is falsy -> duckdb (semantics preserved under SecretStr).
+        assert PRMEConfig(database_url="").backend == "duckdb"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed close() and atexit safety net (issue #37)
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedClose:
+    """close() surfaces encryption failures instead of silently leaving plaintext."""
+
+    @pytest.fixture
+    def enc_dir(self, tmp_dir):
+        lexical = tmp_dir / "lexical_index"
+        lexical.mkdir()
+        return tmp_dir
+
+    @pytest.fixture
+    def enc_config(self, enc_dir):
+        from prme.config import PRMEConfig
+
+        return PRMEConfig(
+            db_path=str(enc_dir / "memory.duckdb"),
+            vector_path=str(enc_dir / "vectors.usearch"),
+            lexical_path=str(enc_dir / "lexical_index"),
+            encryption_enabled=True,
+            encryption_key="fail-closed-passphrase",
+        )
+
+    @pytest.mark.asyncio
+    async def test_close_reraises_on_encryption_failure(self, enc_config):
+        from prme.storage.engine import MemoryEngine
+
+        engine = await MemoryEngine.create(enc_config)
+        await engine.store(content="data", user_id="user-1")
+
+        # Force encryption to fail at close time.
+        def boom():
+            raise RuntimeError("simulated encrypt failure")
+
+        engine._encrypt_memory_pack = boom  # type: ignore[method-assign]
+        with pytest.raises(EncryptionError, match="plaintext on disk"):
+            await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_atexit_registered_when_encryption_enabled(self, enc_config):
+        from prme.storage.engine import MemoryEngine
+
+        engine = await MemoryEngine.create(enc_config)
+        try:
+            assert engine._atexit_registered is True
+        finally:
+            await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_atexit_unregistered_after_clean_close(self, enc_config):
+        from prme.storage.engine import MemoryEngine
+
+        engine = await MemoryEngine.create(enc_config)
+        await engine.store(content="data", user_id="user-1")
+        await engine.close()
+        assert engine._atexit_registered is False
+
+    @pytest.mark.asyncio
+    async def test_atexit_handler_noop_after_close(self, enc_config):
+        from prme.storage.engine import MemoryEngine
+
+        engine = await MemoryEngine.create(enc_config)
+        await engine.store(content="data", user_id="user-1")
+        await engine.close()
+        # Re-encryption already happened; calling the handler must not raise
+        # or double-encrypt (early-returns on _closed).
+        engine._atexit_encrypt()
+
+    @pytest.mark.asyncio
+    async def test_not_registered_without_encryption(self, tmp_dir):
+        from prme.config import PRMEConfig
+        from prme.storage.engine import MemoryEngine
+
+        lexical = tmp_dir / "lexical_index"
+        lexical.mkdir()
+        config = PRMEConfig(
+            db_path=str(tmp_dir / "memory.duckdb"),
+            vector_path=str(tmp_dir / "vectors.usearch"),
+            lexical_path=str(lexical),
+        )
+        engine = await MemoryEngine.create(config)
+        try:
+            assert engine._atexit_registered is False
+        finally:
+            await engine.close()


### PR DESCRIPTION
## Summary

- Encryption-at-rest now fails closed: `close()` logs at ERROR and raises `EncryptionError` if it can't re-encrypt the pack, instead of silently leaving plaintext on disk. The sync `MemoryClient.close()` propagates the same signal.
- Encrypt/decrypt writes are now atomic (temp file + fsync + `os.replace`); the source is removed only after the destination is durable, so a crash never leaves a truncated/partial file. A best-effort `atexit` handler re-encrypts on normal exit, narrowing (not eliminating) the plaintext window — the residual hard-crash window is now documented.
- Removes passphrase/raw-key guessing via explicit `passphrase:` / `raw_key:` prefixes (auto-detection unchanged and still default, so existing packs decrypt), and wraps the three secret config fields in `pydantic.SecretStr` so they're masked in reprs, dumps, and tracebacks.

Deliberately out of scope (left for separate, reviewed work): DuckDB native encryption and any change to the on-disk format, KDF, or default key interpretation — those could lock an existing user out of an already-encrypted pack.

## Test plan

- [x] `uv run pytest -q` — full suite green (1149 passed, 25 skipped PostgreSQL)
- [x] 18 new tests: atomic write (no temp leftovers; plaintext survives a failed rename), fail-closed `close()` re-raises, `atexit` register/unregister + no-op-after-close, `raw_key:`/`passphrase:` prefixes incl. roundtrips, `SecretStr` masking + `backend` property semantics
- [x] `ruff check` clean on all changed files (pre-existing `cli.py` F541s untouched)
- [ ] Manual: enable encryption, store, clean close → files encrypted; reopen with right key → data intact; wrong key → refuses; config dump shows secrets masked

Fixes #37