### PR TITLE
fix: evict superseded/archived content from search indexes (#41)

### DIFF
--- a/docs/RFC-0015-Self-Organizing-Memory.md
+++ b/docs/RFC-0015-Self-Organizing-Memory.md
@@ -238,6 +238,9 @@ async def organize(
 | `feedback_apply` | Apply all pending feedback signals | RFC-0008, RFC-0009 |
 | `centrality_boost` | Recalculate graph centrality salience boost | RFC-0007 §11 |
 | `tombstone_sweep` | Enforce retention policies and create tombstones | RFC-0007 §9 |
+| `snapshot_generation` | Generate entity snapshots for active entities | RFC-0006 |
+| `consolidate` | Cluster similar memories into summary abstractions | RFC-0006 |
+| `index_compaction` | Evict vector/lexical entries for inactive nodes | RFC-0002 |
 
 ### 5.4 OrganizeResult
 

--- a/memory_bank/reviews/issue-41-index-deletion-on-supersede-archive-review.md
+++ b/memory_bank/reviews/issue-41-index-deletion-on-supersede-archive-review.md
@@ -1,0 +1,53 @@
+# Review — issue-41 index deletion on supersede/archive
+
+## Files Changed
+- `src/prme/storage/lexical_index.py` — real `delete_by_node_id` (tantivy `delete_documents_by_term` + own short-lived writer + commit/reload), replacing the warn-only stub.
+- `src/prme/storage/vector_index.py` — new `delete_by_node_id`/`_do_delete` (usearch `Index.remove` + `vector_metadata` delete + immediate save); added module logger.
+- `src/prme/storage/pg/vector_index.py` — new `delete_by_node_id` (nulls `nodes.embedding`) for backend parity; removed pre-existing unused `numpy` import.
+- `src/prme/storage/engine.py` — `supersede()`/`archive()` now evict via new `_evict_from_indexes()`; `consolidate_knowledge()` upserts the entity-profile SUMMARY (archive+evict prior) instead of appending duplicates.
+- `src/prme/storage/write_queue.py` — `WriteTracker.rollback()` gains optional `vector_index`/`lexical_index` and evicts orphaned entries; stale "cleanup deferred" comment replaced.
+- `src/prme/ingestion/pipeline.py` — passes the indexes into `tracker.rollback()`.
+- `src/prme/organizer/jobs.py` — new `index_compaction` job reconciling `vector_metadata` against active nodes; registered in `ALL_JOBS` + dispatch; uses `ACTIVE_LIFECYCLE_STATES`.
+- `docs/RFC-0015-Self-Organizing-Memory.md` — Available Jobs table updated (snapshot_generation, consolidate, index_compaction).
+
+## Approach Summary
+Superseded/archived/rolled-back content is now evicted from the vector (usearch + DuckDB metadata) and lexical (tantivy) indexes at the lifecycle transition, with a best-effort contract (graph transition never undone by an index failure). The `index_compaction` organizer job is the backstop that reconciles index drift left by any failed inline eviction. `consolidate_knowledge` upserts profiles to stop duplicate SUMMARY growth. Eviction is reconstructable from the append-only event log, so it is non-destructive.
+
+## Must Fix
+1. `PgVectorIndex` was missing `delete_by_node_id` → `AttributeError` on the PG backend path. **Fixed** (added method, returns int count, mirrors DuckDB contract).
+2. Duplicated active-states literal in the compaction job. **Fixed** (now uses `ACTIVE_LIFECYCLE_STATES` from `prme.types`, dynamic placeholder count).
+
+## Should Fix
+3. Silent `except Exception: pass` on usearch `remove`. **Fixed** (narrowed to `(KeyError, ValueError, RuntimeError)` + debug log).
+4. RFC-0015 job table outdated. **Fixed** (three missing jobs added).
+
+## Investigated and Rejected (verified non-issues)
+- "tantivy writer lock conflict in `_do_delete`": `_commit_locked` releases `self._writer` synchronously before the delete writer is created; verified by a delete-after-buffered-add + re-add test. No conflict.
+- "SQL `list(active)` with `(?, ?, ?)` is unsafe/broken": verified DuckDB binds a Python list positionally and correctly; query returns expected rows. (Still switched to dynamic placeholders for robustness.)
+- Lambda closure binding in eviction/rollback: correct default-arg capture; submit accepts the coroutine-factory lambda as used everywhere else.
+- OrganizerConfig enable-flag for the job: intentionally always-on (correctness backstop, same as `tombstone_sweep` which also has no flag).
+
+## Security Audit Results
+| Area | Result | Details |
+|---|---|---|
+| SQL injection | PASS | All deletes/reads parameterized; no interpolation of user data. |
+| Tenant isolation | PASS | `node_id` is a globally-unique UUID, 1:1 with a user; callers operate on in-scope nodes; consolidate queries are `user_id`-scoped. |
+| Destructive ops | PASS | Index entries only; event log and graph untouched (archive is a state transition); rebuildable. |
+| PII in logs | PASS | Only `node_id`/`vector_key` logged, never content. |
+
+## Pattern Consistency Assessment
+New delete methods mirror existing `index()`/`_do_*` lock + `asyncio.to_thread` split. The job matches the `_job_*(job_name, engine, config, budget_ms)->JobResult` shape, budget checks, `time.monotonic` timing, and `getattr(engine, "_conn")` pattern used by `tombstone_sweep`. Backend parity restored (both PG indexes now have `delete_by_node_id`).
+
+## Redundancy Check
+`_evict_from_indexes` (lifecycle transitions) and `WriteTracker.rollback` eviction (materialization failure) are different contexts sharing the same `delete_by_node_id` primitives — not duplication. No new dependencies (usearch.remove, tantivy.delete_documents_by_term already present).
+
+## Wiring Findings
+Job registered in both `ALL_JOBS` and dispatch; runs by default via `organize()`. `tests/test_organizer.py` and `tests/test_self_organizing_integration.py` assert `set(jobs_run)==set(ALL_JOBS)` and `jobs_skipped==[]` — the new job runs cleanly on the real-DuckDB fixtures (vector_metadata + nodes tables present), so those assertions still hold. Only caller of `rollback` updated.
+
+## Resolution Status
+| # | Severity | Status |
+|---|---|---|
+| 1 | Must Fix | Resolved |
+| 2 | Must Fix | Resolved |
+| 3 | Should Fix | Resolved |
+| 4 | Should Fix | Resolved |

--- a/src/prme/ingestion/pipeline.py
+++ b/src/prme/ingestion/pipeline.py
@@ -489,8 +489,14 @@ class IngestionPipeline:
                 event_id=event_id,
                 exc_info=True,
             )
-            # Rollback all graph artifacts from this event
-            await tracker.rollback(self._graph_store, self._write_queue)
+            # Rollback all graph artifacts from this event, including any
+            # vector/lexical index entries written before the failure.
+            await tracker.rollback(
+                self._graph_store,
+                self._write_queue,
+                vector_index=self._vector_index,
+                lexical_index=self._lexical_index,
+            )
             logger.info(
                 "ingestion.rollback_complete",
                 event_id=event_id,

--- a/src/prme/organizer/jobs.py
+++ b/src/prme/organizer/jobs.py
@@ -9,6 +9,7 @@ implementations.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timedelta, timezone
@@ -17,7 +18,7 @@ from typing import TYPE_CHECKING
 from prme.config import OrganizerConfig
 from prme.organizer.decay import compute_effective_confidence, compute_effective_salience
 from prme.organizer.models import JobResult
-from prme.types import LifecycleState, NodeType
+from prme.types import ACTIVE_LIFECYCLE_STATES, LifecycleState, NodeType
 
 if TYPE_CHECKING:
     from prme.storage.engine import MemoryEngine
@@ -36,6 +37,7 @@ ALL_JOBS: list[str] = [
     "tombstone_sweep",
     "snapshot_generation",
     "consolidate",
+    "index_compaction",
 ]
 
 
@@ -71,6 +73,7 @@ async def run_job(
         "tombstone_sweep": _job_tombstone_sweep,
         "snapshot_generation": _job_snapshot_generation,
         "consolidate": _job_consolidate,
+        "index_compaction": _job_index_compaction,
     }
 
     handler = dispatch.get(job_name)
@@ -733,6 +736,87 @@ async def _job_summarize(
         errors=total_errors,
         duration_ms=round(duration_ms, 2),
         details=details,
+    )
+
+
+async def _job_index_compaction(
+    job_name: str,
+    engine: MemoryEngine,
+    config: OrganizerConfig,
+    budget_ms: float,
+) -> JobResult:
+    """Reconcile the vector/lexical indexes against active graph nodes (#41).
+
+    Lifecycle transitions evict nodes from the search indexes inline, but a
+    crash between the graph write and the index delete can leave a stale
+    entry behind. This job is the backstop: it finds every node that still
+    has a ``vector_metadata`` row but is no longer active (superseded,
+    deprecated, archived, or deleted) and evicts it from both indexes so
+    the indexes do not accumulate orphaned content.
+
+    The vector_metadata table is the reconciliation anchor because every
+    indexed node has a row there; the matching lexical doc is evicted by
+    node_id at the same time.
+    """
+    start = time.monotonic()
+
+    conn = getattr(engine, "_conn", None)
+    if conn is None:
+        # PostgreSQL backend reconciles via its own mechanisms; nothing to do.
+        duration_ms = (time.monotonic() - start) * 1000.0
+        return JobResult(
+            job=job_name,
+            duration_ms=round(duration_ms, 2),
+            details={"note": "No DuckDB connection; compaction skipped"},
+        )
+
+    # Use the canonical active-state set so this stays in sync with the
+    # lifecycle filter applied at retrieval time (vector_index search).
+    active = [s.value for s in ACTIVE_LIFECYCLE_STATES]
+    placeholders = ", ".join("?" for _ in active)
+
+    def _find_stale() -> list[str]:
+        # Node either missing from the graph (LEFT JOIN NULL) or in a
+        # non-active lifecycle state. DISTINCT so a node with several
+        # vectors is evicted once.
+        rows = conn.execute(
+            "SELECT DISTINCT vm.node_id FROM vector_metadata vm "
+            "LEFT JOIN nodes n ON vm.node_id = n.id "
+            "WHERE n.id IS NULL "
+            f"OR COALESCE(n.lifecycle_state, 'tentative') NOT IN ({placeholders})",
+            active,
+        ).fetchall()
+        return [row[0] for row in rows]
+
+    stale_ids = await asyncio.to_thread(_find_stale)
+
+    processed = 0
+    modified = 0
+    errors = 0
+    for node_id in stale_ids:
+        elapsed_ms = (time.monotonic() - start) * 1000.0
+        if elapsed_ms >= budget_ms:
+            break
+        processed += 1
+        try:
+            await engine._evict_from_indexes(node_id)
+            modified += 1
+        except Exception:
+            logger.warning(
+                "index_compaction.evict_failed",
+                extra={"node_id": node_id},
+                exc_info=True,
+            )
+            errors += 1
+
+    duration_ms = (time.monotonic() - start) * 1000.0
+    return JobResult(
+        job=job_name,
+        nodes_processed=processed,
+        nodes_modified=modified,
+        errors=errors,
+        duration_ms=round(duration_ms, 2),
+        details={"stale_found": len(stale_ids)},
     )
 
 

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -1464,6 +1464,10 @@ class MemoryEngine:
         await self._graph_store.supersede(
             old_node_id, new_node_id, evidence_id=evidence_id
         )
+        # Evict the superseded node from the search indexes so its content
+        # stops surfacing and the indexes do not grow without bound. The
+        # event log remains the source of truth, so this is reconstructable.
+        await self._evict_from_indexes(old_node_id)
 
     async def archive(self, node_id: str) -> None:
         """Archive a node (terminal state).
@@ -1475,6 +1479,38 @@ class MemoryEngine:
             ValueError: If the transition is invalid.
         """
         await self._graph_store.archive(node_id)
+        # Archived content is not retrievable, so drop it from the indexes.
+        await self._evict_from_indexes(node_id)
+
+    async def _evict_from_indexes(self, node_id: str) -> None:
+        """Remove a node's entries from the vector and lexical indexes.
+
+        Best-effort: a failure to evict from a search index must not undo a
+        completed graph lifecycle transition (the node is already marked
+        superseded/archived and is filtered out of vector retrieval by
+        lifecycle state). Each delete is serialized through the WriteQueue
+        to match the rest of the write path, and failures are logged and
+        swallowed. Index drift left by a failure is reconciled by the
+        organizer's index_compaction job.
+        """
+        try:
+            await self._write_queue.submit(
+                lambda nid=node_id: self._vector_index.delete_by_node_id(nid),
+                label=f"evict.vector:{node_id}",
+            )
+        except Exception:
+            logger.warning(
+                "evict.vector_failed", extra={"node_id": node_id}, exc_info=True
+            )
+        try:
+            await self._write_queue.submit(
+                lambda nid=node_id: self._lexical_index.delete_by_node_id(nid),
+                label=f"evict.lexical:{node_id}",
+            )
+        except Exception:
+            logger.warning(
+                "evict.lexical_failed", extra={"node_id": node_id}, exc_info=True
+            )
 
     # --- Snapshots ---
 
@@ -1722,6 +1758,23 @@ class MemoryEngine:
         if not all_nodes:
             return 0
 
+        # Index existing entity-profile SUMMARY nodes by entity name so a
+        # re-run upserts the profile (archive + evict the stale one) instead
+        # of appending a duplicate SUMMARY on every call.
+        existing_profiles: dict[str, list[str]] = {}
+        existing_summaries = await self._graph_store.query_nodes(
+            user_id=user_id,
+            node_type=NodeType.SUMMARY,
+            lifecycle_states=[LifecycleState.TENTATIVE, LifecycleState.STABLE],
+            limit=5000,
+        )
+        for node in existing_summaries:
+            meta = node.metadata or {}
+            if meta.get("entity_profile"):
+                name = meta.get("entity_name")
+                if name:
+                    existing_profiles.setdefault(name, []).append(str(node.id))
+
         # Auto-detect entity names if not provided
         if entity_names is None:
             name_counts: dict[str, int] = {}
@@ -1788,6 +1841,15 @@ class MemoryEngine:
                 continue
 
             profile_text = "\n".join(profile_lines)
+
+            # Upsert: archive and evict any prior profile for this entity so
+            # the SUMMARY is replaced, not duplicated, on each consolidation.
+            for stale_id in existing_profiles.get(entity_name, []):
+                try:
+                    await self.archive(stale_id)
+                except ValueError:
+                    # Already in a terminal state — evict from indexes anyway.
+                    await self._evict_from_indexes(stale_id)
 
             # Store as SUMMARY node
             profile_node = MemoryNode(

--- a/src/prme/storage/lexical_index.py
+++ b/src/prme/storage/lexical_index.py
@@ -287,24 +287,42 @@ class LexicalIndex:
             self._do_search, query_text, user_id, node_type, limit, scope
         )
 
-    async def delete_by_node_id(self, node_id: str) -> None:
-        """Delete a document by node_id (stub for future re-indexing).
+    def _do_delete(self, node_id: str) -> None:
+        """Synchronous delete + commit (runs in thread pool).
 
-        tantivy-py's selective deletion API is not fully documented.
-        For Phase 1, this is a stub that logs a warning. Full re-index
-        via delete_all + re-add is the recommended approach if needed.
+        Removes every document whose ``node_id`` term matches and commits
+        immediately so the deletion is durable and visible to subsequent
+        searches. The ``node_id`` field uses the ``raw`` tokenizer, so the
+        term matches the stored id exactly (no stemming/punctuation
+        surprises). Any documents still buffered in the current batch are
+        committed first so the delete cannot miss a not-yet-committed add
+        for the same node_id.
+        """
+        # Flush any buffered adds so a delete cannot race an uncommitted
+        # add of the same document.
+        if self._uncommitted > 0:
+            self._commit_locked()
+        writer = self._index.writer(heap_size=50_000_000)
+        try:
+            writer.delete_documents_by_term("node_id", node_id)
+            writer.commit()
+            self._index.reload()
+        finally:
+            writer.wait_merging_threads()
+
+    async def delete_by_node_id(self, node_id: str) -> None:
+        """Delete all documents for ``node_id`` from the index.
+
+        Used to evict superseded, archived, or rolled-back content so it
+        no longer surfaces in search and the index does not grow without
+        bound. The delete is committed immediately (its own short-lived
+        writer), so it is durable and visible to the next ``search``.
 
         Args:
-            node_id: The node_id of the document to delete.
+            node_id: The node_id of the document(s) to delete.
         """
-        import structlog
-
-        logger = structlog.get_logger()
-        logger.warning(
-            "lexical_index.delete_by_node_id is a stub",
-            node_id=node_id,
-            hint="Use full re-index if deletion is needed",
-        )
+        async with self._write_lock:
+            await asyncio.to_thread(self._do_delete, node_id)
 
     async def close(self) -> None:
         """Flush buffered documents and release the writer.

--- a/src/prme/storage/pg/vector_index.py
+++ b/src/prme/storage/pg/vector_index.py
@@ -16,7 +16,6 @@ import logging
 from datetime import datetime
 
 import asyncpg
-import numpy as np
 
 from prme.storage.embedding import EmbeddingProvider
 
@@ -172,6 +171,33 @@ class PgVectorIndex:
                 "distance": distance,
             })
         return results
+
+    async def delete_by_node_id(self, node_id: str) -> int:
+        """Clear the stored vector for a node so it stops surfacing (#41).
+
+        pgvector stores the vector in the ``nodes.embedding`` column, so
+        eviction nulls that column rather than removing a row. Mirrors the
+        DuckDB ``VectorIndex.delete_by_node_id`` contract (returns the number
+        of vectors removed) so lifecycle eviction and the index_compaction
+        job work identically across backends.
+
+        Args:
+            node_id: UUID string of the node whose vector to clear.
+
+        Returns:
+            1 if a stored vector was cleared, 0 otherwise.
+        """
+        async with self._pool.acquire() as conn:
+            result = await conn.execute(
+                "UPDATE nodes SET embedding = NULL "
+                "WHERE id = $1 AND embedding IS NOT NULL",
+                node_id,
+            )
+        # asyncpg returns a status string like "UPDATE 1".
+        try:
+            return int(result.split()[-1])
+        except (ValueError, IndexError):
+            return 0
 
     async def save(self) -> None:
         """No-op — PostgreSQL persists automatically."""

--- a/src/prme/storage/vector_index.py
+++ b/src/prme/storage/vector_index.py
@@ -8,6 +8,7 @@ a DuckDB metadata table. All queries are scoped by user_id.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from datetime import datetime
 
@@ -16,6 +17,8 @@ import numpy as np
 from usearch.index import Index
 
 from prme.storage.embedding import EmbeddingProvider
+
+logger = logging.getLogger(__name__)
 
 
 class VectorIndex:
@@ -233,6 +236,60 @@ class VectorIndex:
                 self._unsaved_inserts = 0
 
         return key
+
+    async def delete_by_node_id(self, node_id: str) -> int:
+        """Remove all vectors for a node from USearch and DuckDB metadata.
+
+        Used to evict superseded, archived, or rolled-back content so the
+        vector keys no longer inflate the per-search candidate scan and the
+        HNSW index does not grow without bound. The index is persisted after
+        a removal so the deletion survives a restart.
+
+        Args:
+            node_id: UUID string of the node whose vectors to remove.
+
+        Returns:
+            The number of vector keys removed (0 if the node had none).
+        """
+        async with self._write_lock:
+            async with self._conn_lock:
+                return await asyncio.to_thread(self._do_delete, node_id)
+
+    def _do_delete(self, node_id: str) -> int:
+        """Synchronous delete from USearch + metadata (runs in thread pool).
+
+        Returns the number of keys removed. Caller must hold both
+        ``_write_lock`` and ``_conn_lock``.
+        """
+        rows = self._conn.execute(
+            "SELECT vector_key FROM vector_metadata WHERE node_id = ?",
+            [node_id],
+        ).fetchall()
+        if not rows:
+            return 0
+
+        keys = [row[0] for row in rows]
+        for key in keys:
+            # USearch raises if the key is absent; tolerate that so a
+            # metadata/index drift (key in metadata but missing from the
+            # HNSW index) does not abort the whole eviction. Logged at
+            # debug for observability rather than silently swallowed.
+            try:
+                self._index.remove(key)
+            except (KeyError, ValueError, RuntimeError) as exc:
+                logger.debug(
+                    "vector_index.remove_missing_key",
+                    extra={"vector_key": key, "node_id": node_id, "error": str(exc)},
+                )
+
+        self._conn.execute(
+            "DELETE FROM vector_metadata WHERE node_id = ?", [node_id]
+        )
+        # Persist immediately so the removal is not lost if the process
+        # exits before the next debounced save.
+        self._index.save(self._index_path)
+        self._unsaved_inserts = 0
+        return len(keys)
 
     async def search(
         self,

--- a/src/prme/storage/write_queue.py
+++ b/src/prme/storage/write_queue.py
@@ -171,12 +171,12 @@ class WriteTracker:
     order (edges first for referential integrity, then nodes) via
     the WriteQueue to maintain serialization.
 
-    Note: Graph rollback only. Vector and lexical index entries for
-    rolled-back nodes will be orphaned -- these stores currently lack
-    delete methods. Orphaned entries are harmless (search returns an
-    ID, get_node returns None, caller handles gracefully). Vector and
-    lexical cleanup will be added when those delete methods are
-    implemented.
+    Vector and lexical index entries for rolled-back nodes are also
+    evicted when the corresponding indexes are passed to rollback(), so a
+    failed materialization does not leave orphaned search-index entries.
+    Eviction is best-effort: a failure to evict from an index is logged
+    and does not abort the rest of the rollback (any residual drift is
+    reconciled by the organizer's index_compaction job).
     """
 
     def __init__(self) -> None:
@@ -201,18 +201,28 @@ class WriteTracker:
         """Return a copy of recorded edge IDs."""
         return list(self._created_edge_ids)
 
-    async def rollback(self, graph_store: object, write_queue: WriteQueue) -> None:
+    async def rollback(
+        self,
+        graph_store: object,
+        write_queue: WriteQueue,
+        vector_index: object | None = None,
+        lexical_index: object | None = None,
+    ) -> None:
         """Delete all tracked writes in reverse order via WriteQueue.
 
         Edges first (referential integrity), then nodes. Best-effort:
         logs warnings on individual delete failures but continues with
-        remaining items.
+        remaining items. When ``vector_index``/``lexical_index`` are
+        provided, each rolled-back node is also evicted from those search
+        indexes so no orphaned entries remain.
 
         Args:
             graph_store: GraphStore instance with delete_node/delete_edge
                 methods. Typed as object to avoid circular import with
                 the GraphStore Protocol.
             write_queue: WriteQueue for serialized delete execution.
+            vector_index: Optional VectorIndex with delete_by_node_id.
+            lexical_index: Optional LexicalIndex with delete_by_node_id.
         """
         for edge_id in reversed(self._created_edge_ids):
             try:
@@ -236,11 +246,24 @@ class WriteTracker:
                     "rollback.node_failed", node_id=node_id, exc_info=True
                 )
 
-        if self._created_node_ids or self._created_edge_ids:
-            logger.warning(
-                "rollback.orphaned_indexes",
-                node_count=len(self._created_node_ids),
-                edge_count=len(self._created_edge_ids),
-                detail="Vector and lexical index entries for rolled-back "
-                "nodes may be orphaned (cleanup deferred to future phase)",
-            )
+            # Evict the node's search-index entries so they are not orphaned.
+            if vector_index is not None:
+                try:
+                    await write_queue.submit(
+                        lambda nid=node_id: vector_index.delete_by_node_id(nid),  # type: ignore[attr-defined]
+                        label=f"rollback.vector:{node_id}",
+                    )
+                except Exception:
+                    logger.warning(
+                        "rollback.vector_failed", node_id=node_id, exc_info=True
+                    )
+            if lexical_index is not None:
+                try:
+                    await write_queue.submit(
+                        lambda nid=node_id: lexical_index.delete_by_node_id(nid),  # type: ignore[attr-defined]
+                        label=f"rollback.lexical:{node_id}",
+                    )
+                except Exception:
+                    logger.warning(
+                        "rollback.lexical_failed", node_id=node_id, exc_info=True
+                    )

--- a/tests/test_index_write_path.py
+++ b/tests/test_index_write_path.py
@@ -343,3 +343,84 @@ async def test_extraction_concurrency_is_bounded(tmp_path: Path, conn) -> None:
     await pipeline.shutdown()
     await wq.stop()
     assert provider.peak <= 3
+
+
+# --- Index deletion (issue #41) ------------------------------------------
+
+
+async def test_vector_delete_by_node_id_removes_vector(
+    tmp_path: Path, conn
+) -> None:
+    """delete_by_node_id drops the vector and its metadata; search misses it."""
+    vidx = VectorIndex(
+        conn, str(tmp_path / "v.usearch"), MockEmbeddingProvider(), save_interval=1
+    )
+    await vidx.index("keep", "alpha content", "u1")
+    await vidx.index("drop", "beta content", "u1")
+
+    # Two vectors are present in the raw HNSW index before deletion.
+    assert len(vidx._index) == 2
+
+    removed = await vidx.delete_by_node_id("drop")
+    assert removed == 1
+
+    # Metadata row for the dropped node is gone; the kept one remains.
+    dropped = conn.execute(
+        "SELECT COUNT(*) FROM vector_metadata WHERE node_id = ?", ["drop"]
+    ).fetchone()[0]
+    assert dropped == 0
+    kept = conn.execute(
+        "SELECT COUNT(*) FROM vector_metadata WHERE node_id = ?", ["keep"]
+    ).fetchone()[0]
+    assert kept == 1
+
+    # The key is removed from the HNSW index itself, not just the metadata.
+    assert len(vidx._index) == 1
+
+    await vidx.close()
+
+
+async def test_vector_delete_missing_node_is_noop(tmp_path: Path, conn) -> None:
+    """Deleting a node with no vectors returns 0 and does not raise."""
+    vidx = VectorIndex(
+        conn, str(tmp_path / "v.usearch"), MockEmbeddingProvider(), save_interval=1
+    )
+    removed = await vidx.delete_by_node_id("never-indexed")
+    assert removed == 0
+    await vidx.close()
+
+
+async def test_lexical_delete_by_node_id_removes_doc(tmp_path: Path) -> None:
+    """delete_by_node_id removes a document so it no longer surfaces."""
+    lex_path = tmp_path / "lexical"
+    lex_path.mkdir()
+    lidx = LexicalIndex(str(lex_path), commit_interval=100, commit_max_delay_s=0.0)
+
+    await lidx.index("keep", "shared keyword here", "u1", "fact", "PERSONAL")
+    await lidx.index("drop", "shared keyword too", "u1", "fact", "PERSONAL")
+
+    await lidx.delete_by_node_id("drop")
+
+    results = await lidx.search("shared keyword", "u1", limit=10)
+    ids = {r["node_id"] for r in results}
+    assert "keep" in ids
+    assert "drop" not in ids
+
+    await lidx.close()
+
+
+async def test_lexical_delete_then_reindex_same_node(tmp_path: Path) -> None:
+    """A node can be re-indexed after deletion (delete flushes buffered adds)."""
+    lex_path = tmp_path / "lexical"
+    lex_path.mkdir()
+    lidx = LexicalIndex(str(lex_path), commit_interval=100, commit_max_delay_s=0.0)
+
+    await lidx.index("n1", "first version", "u1", "fact", "PERSONAL")
+    await lidx.delete_by_node_id("n1")
+    assert await lidx.search("first version", "u1", limit=5) == []
+
+    await lidx.index("n1", "second version", "u1", "fact", "PERSONAL")
+    results = await lidx.search("second version", "u1", limit=5)
+    assert any(r["node_id"] == "n1" for r in results)
+
+    await lidx.close()

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -1132,3 +1132,141 @@ class TestOrganizeIntegration:
             str(archivable.id), include_superseded=True
         )
         assert refreshed_archivable.lifecycle_state == LifecycleState.ARCHIVED
+
+
+# ---------------------------------------------------------------------------
+# Index deletion / compaction (issue #41)
+# ---------------------------------------------------------------------------
+
+
+def _vector_keys(conn, node_id: str) -> list[int]:
+    """Return the vector_metadata keys recorded for a node."""
+    return [
+        row[0]
+        for row in conn.execute(
+            "SELECT vector_key FROM vector_metadata WHERE node_id = ?",
+            [node_id],
+        ).fetchall()
+    ]
+
+
+class TestIndexDeletion:
+    """Lexical/vector eviction on lifecycle transitions and compaction (#41)."""
+
+    @pytest.mark.asyncio
+    async def test_archive_evicts_from_indexes(self, engine_parts):
+        """engine.archive() removes the node from both search indexes."""
+        engine, graph_store, conn = engine_parts
+
+        node = _make_node(content="archivable content about Saturn")
+        await graph_store.create_node(node)
+        await engine._vector_index.index(str(node.id), node.content, node.user_id)
+        await engine._lexical_index.index(
+            str(node.id), node.content, node.user_id, "fact", "PERSONAL"
+        )
+        assert _vector_keys(conn, str(node.id)) != []
+
+        await engine.archive(str(node.id))
+
+        # Vector metadata is gone and lexical search no longer returns it.
+        assert _vector_keys(conn, str(node.id)) == []
+        lex = await engine._lexical_index.search("Saturn", node.user_id, limit=10)
+        assert all(r["node_id"] != str(node.id) for r in lex)
+
+    @pytest.mark.asyncio
+    async def test_supersede_evicts_old_node(self, engine_parts):
+        """engine.supersede() evicts the superseded node from the indexes."""
+        engine, graph_store, conn = engine_parts
+
+        old = _make_node(content="old value about Jupiter")
+        new = _make_node(content="new value about Jupiter")
+        await graph_store.create_node(old)
+        await graph_store.create_node(new)
+        await engine._vector_index.index(str(old.id), old.content, old.user_id)
+        await engine._lexical_index.index(
+            str(old.id), old.content, old.user_id, "fact", "PERSONAL"
+        )
+
+        await engine.supersede(str(old.id), str(new.id))
+
+        assert _vector_keys(conn, str(old.id)) == []
+        lex = await engine._lexical_index.search("Jupiter", old.user_id, limit=10)
+        assert all(r["node_id"] != str(old.id) for r in lex)
+
+    @pytest.mark.asyncio
+    async def test_index_compaction_job_reconciles_stale_entries(
+        self, engine_parts
+    ):
+        """The compaction job evicts vectors whose node is no longer active."""
+        engine, graph_store, conn = engine_parts
+        config = OrganizerConfig()
+
+        active = _make_node(content="active fact")
+        stale = _make_node(content="stale fact")
+        await graph_store.create_node(active)
+        await graph_store.create_node(stale)
+        await engine._vector_index.index(str(active.id), active.content, "test-user")
+        await engine._vector_index.index(str(stale.id), stale.content, "test-user")
+
+        # Archive the node directly in the graph (bypassing engine eviction)
+        # to simulate index drift the compaction job must repair.
+        await graph_store.archive(str(stale.id))
+        assert _vector_keys(conn, str(stale.id)) != []  # drift present
+
+        result = await run_job("index_compaction", engine, config, 5000.0)
+
+        assert isinstance(result, JobResult)
+        assert result.job == "index_compaction"
+        assert result.nodes_modified >= 1
+        # Stale node evicted; active node untouched.
+        assert _vector_keys(conn, str(stale.id)) == []
+        assert _vector_keys(conn, str(active.id)) != []
+
+    @pytest.mark.asyncio
+    async def test_index_compaction_evicts_orphaned_vectors(self, engine_parts):
+        """Vectors whose graph node was deleted entirely are reconciled."""
+        engine, graph_store, conn = engine_parts
+        config = OrganizerConfig()
+
+        node = _make_node(content="will be orphaned")
+        await graph_store.create_node(node)
+        await engine._vector_index.index(str(node.id), node.content, "test-user")
+        # Delete the graph node without touching the index (orphan the vector).
+        await graph_store.delete_node(str(node.id))
+        assert _vector_keys(conn, str(node.id)) != []
+
+        await run_job("index_compaction", engine, config, 5000.0)
+
+        assert _vector_keys(conn, str(node.id)) == []
+
+    @pytest.mark.asyncio
+    async def test_consolidate_knowledge_upserts_profile(self, engine_parts):
+        """Re-running consolidation replaces the entity profile, not duplicates."""
+        engine, graph_store, conn = engine_parts
+
+        # Several nodes mentioning the same entity so a profile is built.
+        for i in range(4):
+            n = _make_node(
+                content=f"Aurora reported metric {i} during the review",
+            )
+            await graph_store.create_node(n)
+
+        first = await engine.consolidate_knowledge(
+            user_id="test-user", entity_names=["Aurora"]
+        )
+        assert first == 1
+
+        def _active_profiles() -> int:
+            return conn.execute(
+                "SELECT COUNT(*) FROM nodes "
+                "WHERE node_type = 'summary' "
+                "AND lifecycle_state IN ('tentative', 'stable', 'contested')"
+            ).fetchone()[0]
+
+        assert _active_profiles() == 1
+
+        # Re-run: the prior profile is archived, a fresh one created -> still 1.
+        await engine.consolidate_knowledge(
+            user_id="test-user", entity_names=["Aurora"]
+        )
+        assert _active_profiles() == 1


### PR DESCRIPTION
## Summary

- Implement real deletion on both search indexes: the tantivy `LexicalIndex` (previously a warn-only stub) and the usearch `VectorIndex` now remove a node's entries by id, with a matching method added to `PgVectorIndex` for backend parity. Superseded/archived content no longer surfaces in lexical search, and the indexes stop growing without bound.
- Evict from both indexes on `supersede()` and `archive()` (best-effort, so a search-index failure never undoes a committed graph transition), and on materialization rollback so a failed ingest leaves no orphaned entries.
- Make `consolidate_knowledge` upsert the entity profile (archive + evict the prior `SUMMARY` before writing the new one) instead of appending a duplicate on every run. Add an `index_compaction` organizer job that reconciles the indexes against active nodes as a backstop for any drift.

Eviction is non-destructive: index entries are reconstructable from the append-only event log.

## Test plan

- [x] `uv run pytest -q` — full suite green (1158 passed, 25 skipped PostgreSQL)
- [x] New index-level tests: vector/lexical `delete_by_node_id` remove the entry; deleting a node with no entry is a no-op; a node can be re-indexed after deletion
- [x] New engine/organizer tests: `archive()` and `supersede()` evict from both indexes; `index_compaction` reconciles stale and orphaned vectors while leaving active nodes; re-running `consolidate_knowledge` keeps exactly one active profile per entity
- [x] `ruff check` clean on all changed source/test files

## How to verify manually

1. Store a few memories that mention the same entity, then store a contradicting assertion so the old one is superseded.
2. Run a lexical search for a term unique to the superseded content — it should no longer appear in results.
3. Run `consolidate_knowledge` for that entity twice; confirm only one active `SUMMARY` profile node exists afterward (no duplicates).
4. Run `organize()` (or the `index_compaction` job) and confirm vector/lexical entries for archived nodes are cleaned up.

Fixes #41