### PR TITLE
feat: deterministic vector search + prme rebuild (#45)

### DIFF
--- a/memory_bank/reviews/issue-45-determinism-rebuild-review.md
+++ b/memory_bank/reviews/issue-45-determinism-rebuild-review.md
@@ -1,0 +1,79 @@
+# Code Review — issue-45-determinism-rebuild
+
+## Files Changed
+- `src/prme/config.py` — new `vector_exact_search` bool field (default True).
+- `src/prme/storage/vector_index.py` — `exact_search` ctor param; `exact=` on usearch search; new `clear()`/`_do_clear()`.
+- `src/prme/storage/lexical_index.py` — new `clear()`/`_do_clear()`.
+- `src/prme/storage/engine.py` — wire `exact_search` from config; new `rebuild_indexes()`; import `ACTIVE_LIFECYCLE_STATES`.
+- `src/prme/cli.py` — new `cmd_rebuild` handler + `rebuild` subparser + docstring entry.
+- `tests/test_determinism_rebuild.py` — new (exact determinism, clear, rebuild, harness).
+- `tests/test_cli.py` — new rebuild CLI tests + parser test.
+
+## Approach Summary
+Delivers the determinism and rebuildability claims for issue #45 with a bounded,
+non-destructive change. (1) Exact vector search: pass `exact=True` to usearch
+(brute-force cosine, order-independent) gated by a config flag, default on.
+(2) `prme rebuild`: clears the *derived* vector + lexical indexes and reconstructs
+them from the durable graph nodes (active lifecycle states only), in deterministic
+id order. The event log and graph nodes/edges (the source of truth) are never
+modified, so rebuild is safe to re-run and idempotent. Builds on PR #38 (lifecycle
+visibility filter) and PR #41 (eviction/compaction) — rebuild indexes the same
+active set those enforce.
+
+## Must Fix
+- None. (6-agent review found no correctness, security, or wiring defect that
+  blocks the bounded scope.)
+
+## Should Fix (resolved)
+- **Postgres ignores the exact-search flag silently** (Agents 5, 6). Resolved by
+  documenting in the config field description that the flag applies to the
+  DuckDB/USearch backend only (pgvector uses its own index). Changing Postgres
+  ANN semantics is out of scope for this PR and would be a behavior change.
+- **`placeholders` recomputed each loop iteration** (Agents 3, 4). Resolved —
+  hoisted out of the pagination loop (loop-invariant).
+- **Missing tests: empty graph + whitespace-only content skip** (Agents 1, 3).
+  Resolved — added `test_rebuild_empty_graph` and `test_rebuild_skips_empty_content`.
+
+## Consider (acknowledged, not changed)
+- **rebuild reads the nodes table via raw SQL rather than `graph_store.query_nodes()`**
+  (Agent 4). Deliberate: rebuild is DuckDB-only (guarded), and it needs
+  `ORDER BY id` for determinism, which `query_nodes` (orders by `created_at`)
+  does not provide. The direct read matches how `cmd_stats`/`cmd_info` read the
+  same connection. Documented inline.
+
+## Security Audit Results
+All six areas PASS (Agent 2):
+- SQL injection: PASS — only `?` placeholders interpolated into the IN clause;
+  all values parameterized (matches `_fetch_allowed_keys`).
+- Tenant isolation: PASS — per-node `user_id` carried into both index writes;
+  search still filters by user at query time.
+- Path traversal: PASS — CLI reuses `_create_engine` (abspath + existence check).
+- Data destruction: PASS — only derived indexes cleared; graph nodes remain, so
+  rebuild rehydrates from authoritative data (recoverable, non-destructive).
+- PII in logs: PASS — completion log emits aggregate counts only, no content/ids.
+
+## Pattern Consistency Assessment
+PASS (Agent 4): config field matches existing bool-field shape; `clear()`/`_do_clear()`
+mirror `delete_by_node_id()`/`_do_delete()` lock + thread patterns in both index
+modules; `write_queue.submit(lambda: ...)` idiom matches `store()`; CLI subparser
+matches `cmd_organize`.
+
+## Redundancy Check
+PASS (Agent 5): no existing rebuild/reindex/clear path; `index_compaction` (#41) is
+orthogonal (evicts stale vs reconstructs all). `clear()` (bulk reset) justified over
+looping `delete_by_node_id`. No new dependencies (usearch `exact=` and tantivy
+`delete_all_documents` are existing APIs).
+
+## Wiring Findings
+PASS (Agent 6) for DuckDB path: config → VectorIndex → search; CLI registered and
+dispatched; args resolve; env loads via `PRME_` prefix; docstring/help updated; tests
+discovered. The Postgres-flag gap is addressed via documentation (see Should Fix).
+
+## Resolution Status
+| Finding | Severity | Status |
+|---|---|---|
+| Postgres ignores exact flag | Should Fix | Resolved (documented as DuckDB-only) |
+| `placeholders` in loop | Should Fix | Resolved (hoisted) |
+| Missing empty-graph test | Should Fix | Resolved (added) |
+| Missing empty-content test | Should Fix | Resolved (added) |
+| raw SQL vs query_nodes | Consider | Acknowledged (determinism requires ORDER BY id) |

--- a/src/prme/cli.py
+++ b/src/prme/cli.py
@@ -14,6 +14,7 @@ Commands:
     prme chain <db_path> <id> -- Show supersedence chain
     prme search <db_path> <q> -- Run retrieval query
     prme organize <db_path>  -- Run organizer jobs
+    prme rebuild <db_path>   -- Rebuild indexes from the durable graph
     prme stats <db_path>     -- Show memory statistics
     prme export <db_path>    -- Export memory pack as JSON
 """
@@ -490,6 +491,28 @@ async def cmd_organize(args: argparse.Namespace) -> None:
         await engine.close()
 
 
+async def cmd_rebuild(args: argparse.Namespace) -> None:
+    """Rebuild the vector and lexical indexes from the durable graph.
+
+    Drops the derived search indexes and re-materializes them from the
+    active nodes already persisted in the pack. The event log and graph
+    nodes are never modified, so the rebuild is safe to re-run.
+    """
+    engine = await _create_engine(args.db_path)
+    try:
+        summary = await engine.rebuild_indexes(batch_size=args.batch_size)
+
+        if args.format == "json":
+            print(json.dumps(summary, indent=2))
+        else:
+            print("Rebuild complete:")
+            print(f"  Nodes indexed:  {summary['nodes_indexed']}")
+            print(f"  Nodes skipped:  {summary['nodes_skipped']}")
+            print(f"  Active nodes:   {summary['total_active']}")
+    finally:
+        await engine.close()
+
+
 async def cmd_stats(args: argparse.Namespace) -> None:
     """Show statistics: nodes by type, by state, avg confidence, etc."""
     engine = await _create_engine(args.db_path)
@@ -842,6 +865,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Time budget in milliseconds (default: 5000)",
     )
     p_organize.set_defaults(func=cmd_organize)
+
+    # rebuild
+    p_rebuild = subparsers.add_parser(
+        "rebuild",
+        help="Rebuild vector and lexical indexes from the durable graph",
+    )
+    add_common(p_rebuild)
+    p_rebuild.add_argument(
+        "--batch-size",
+        type=int,
+        default=256,
+        help="Nodes fetched from the graph per page (default: 256)",
+    )
+    p_rebuild.set_defaults(func=cmd_rebuild)
 
     # stats
     p_stats = subparsers.add_parser("stats", help="Show memory statistics")

--- a/src/prme/config.py
+++ b/src/prme/config.py
@@ -413,6 +413,22 @@ class PRMEConfig(BaseSettings):
             "after every insert (legacy behavior)."
         ),
     )
+    vector_exact_search: bool = Field(
+        default=True,
+        description=(
+            "When True, vector search uses brute-force exact cosine nearest "
+            "neighbors instead of the approximate HNSW graph traversal. HNSW "
+            "construction is order- and thread-dependent, so two rebuilds "
+            "from the same event log can return different neighbor sets, "
+            "violating the 'identical log + config -> identical retrieval' "
+            "determinism claim. Exact search is order-independent and makes "
+            "retrieval reproducible. At current corpus sizes (<100k vectors) "
+            "brute-force cosine is fast. Set to False to trade determinism "
+            "for sub-linear ANN latency on very large corpora. Applies to "
+            "the DuckDB/USearch backend only; the PostgreSQL backend uses "
+            "pgvector's own index and ignores this flag."
+        ),
+    )
     lexical_commit_interval: int = Field(
         default=64,
         ge=1,

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -44,6 +44,7 @@ from prme.storage.schema import initialize_database
 from prme.storage.vector_index import VectorIndex
 from prme.storage.write_queue import NoOpWriteQueue, WriteQueue
 from prme.types import (
+    ACTIVE_LIFECYCLE_STATES,
     DecayProfile,
     EpistemicType,
     LifecycleState,
@@ -251,6 +252,7 @@ class MemoryEngine:
             embedding_provider,
             conn_lock,
             save_interval=config.vector_save_interval,
+            exact_search=config.vector_exact_search,
         )
 
         # Create lexical index
@@ -1511,6 +1513,144 @@ class MemoryEngine:
             logger.warning(
                 "evict.lexical_failed", extra={"node_id": node_id}, exc_info=True
             )
+
+    # --- Rebuild (issue #45) ---
+
+    async def rebuild_indexes(self, *, batch_size: int = 256) -> dict[str, int]:
+        """Rebuild the vector and lexical indexes from the durable graph.
+
+        Drops both derived search indexes and re-materializes them from the
+        active nodes already persisted in the graph store (the ``nodes``
+        table in the DuckDB pack), embedding each node's content afresh.
+
+        This delivers the rebuildability claim while staying bounded and
+        non-destructive: it touches only the *derived* search artifacts
+        (``vectors.usearch`` and the lexical index directory). The event log
+        and the graph nodes/edges -- the durable source of truth -- are never
+        modified, so a rebuild is safe to re-run and idempotent. It is the
+        clean recovery path for index corruption, embedding-model migration,
+        and the index drift left when an eviction fails (the same drift the
+        ``index_compaction`` organizer job reconciles, issue #41).
+
+        Only nodes in active lifecycle states (tentative/stable/contested)
+        are re-indexed, matching the visibility contract that vector and
+        lexical search already enforce (issue #38) -- superseded, archived,
+        and deprecated nodes are intentionally left out of the indexes.
+
+        Nodes are processed in deterministic ``id`` order so that, combined
+        with exact vector search (``vector_exact_search``), two rebuilds from
+        the same pack produce identical indexes and identical retrieval.
+
+        Args:
+            batch_size: Number of nodes to fetch from the graph per page.
+                Bounds peak memory on large packs; does not affect results.
+
+        Returns:
+            A summary dict with counts: ``nodes_indexed`` (rows written to
+            both indexes), ``nodes_skipped`` (active rows with empty content,
+            which cannot be embedded), and ``total_active`` (active rows
+            seen).
+        """
+        if self._conn is None:
+            raise RuntimeError(
+                "rebuild_indexes is only supported on the DuckDB backend"
+            )
+
+        active_states = [s.value for s in ACTIVE_LIFECYCLE_STATES]
+
+        # Clear both derived indexes first (serialized through the write
+        # queue like every other index mutation). After this point the
+        # indexes are empty; the re-index loop below repopulates them.
+        await self._write_queue.submit(
+            lambda: self._vector_index.clear(),
+            label="rebuild.clear.vector",
+        )
+        await self._write_queue.submit(
+            lambda: self._lexical_index.clear(),
+            label="rebuild.clear.lexical",
+        )
+
+        nodes_indexed = 0
+        nodes_skipped = 0
+        total_active = 0
+        offset = 0
+        placeholders = ", ".join("?" for _ in active_states)
+
+        while True:
+            # Page through active nodes in deterministic id order. Reading
+            # the nodes table directly (rather than the graph_store query
+            # API) keeps the rebuild user-agnostic -- every active node in
+            # the pack is re-indexed regardless of owner -- and lets us
+            # ORDER BY id for reproducibility (query_nodes orders by
+            # created_at). The rebuild is already gated to the DuckDB
+            # backend above, so direct SQL is safe here.
+            rows = await asyncio.to_thread(
+                lambda ph=placeholders, off=offset: self._conn.execute(
+                    "SELECT id, content, user_id, node_type, scope "
+                    "FROM nodes "
+                    f"WHERE COALESCE(lifecycle_state, 'tentative') IN ({ph}) "
+                    "ORDER BY id "
+                    "LIMIT ? OFFSET ?",
+                    [*active_states, batch_size, off],
+                ).fetchall(),
+            )
+            if not rows:
+                break
+
+            for row in rows:
+                total_active += 1
+                node_id = str(row[0])
+                content = row[1]
+                user_id = row[2]
+                node_type = row[3]
+                scope = row[4]
+
+                if not content or not content.strip():
+                    # Empty content cannot be embedded; skip but count it so
+                    # the caller can reconcile against total node counts.
+                    nodes_skipped += 1
+                    continue
+
+                await self._write_queue.submit(
+                    lambda nid=node_id, c=content, uid=user_id: (
+                        self._vector_index.index(nid, c, uid)
+                    ),
+                    label=f"rebuild.vector:{node_id}",
+                )
+                await self._write_queue.submit(
+                    lambda nid=node_id, c=content, uid=user_id, nt=node_type, sc=scope: (
+                        self._lexical_index.index(nid, c, uid, nt, sc)
+                    ),
+                    label=f"rebuild.lexical:{node_id}",
+                )
+                nodes_indexed += 1
+
+            offset += batch_size
+
+        # Flush pending index writes to disk so the rebuilt artifacts are
+        # durable even if the process exits before the next debounced save.
+        await self._write_queue.submit(
+            lambda: self._vector_index.save(),
+            label="rebuild.save.vector",
+        )
+        await self._write_queue.submit(
+            lambda: self._lexical_index.flush(),
+            label="rebuild.flush.lexical",
+        )
+
+        logger.info(
+            "rebuild_indexes.complete",
+            extra={
+                "nodes_indexed": nodes_indexed,
+                "nodes_skipped": nodes_skipped,
+                "total_active": total_active,
+            },
+        )
+        return {
+            "nodes_indexed": nodes_indexed,
+            "nodes_skipped": nodes_skipped,
+            "total_active": total_active,
+        }
 
     # --- Snapshots ---
 

--- a/src/prme/storage/lexical_index.py
+++ b/src/prme/storage/lexical_index.py
@@ -324,6 +324,38 @@ class LexicalIndex:
         async with self._write_lock:
             await asyncio.to_thread(self._do_delete, node_id)
 
+    def _do_clear(self) -> None:
+        """Synchronous delete-all + commit (runs in thread pool).
+
+        Drops every document so the index can be rebuilt from the durable
+        graph nodes (issue #45). Any buffered adds are discarded first, then
+        a short-lived writer deletes all documents and commits so the empty
+        state is durable and visible to subsequent searches.
+        """
+        # Drop any buffered adds: they are about to be re-indexed from the
+        # graph, so committing them first would be wasted work.
+        self._writer = None
+        self._uncommitted = 0
+        self._oldest_uncommitted_at = None
+        writer = self._index.writer(heap_size=50_000_000)
+        try:
+            writer.delete_all_documents()
+            writer.commit()
+            self._index.reload()
+        finally:
+            writer.wait_merging_threads()
+
+    async def clear(self) -> None:
+        """Delete every document, leaving an empty index.
+
+        Resets the lexical index to a clean slate so it can be rebuilt from
+        the durable graph nodes (issue #45). The deletion is committed
+        immediately so a crash mid-rebuild leaves a consistent (empty) index.
+        Caller is responsible for re-indexing afterwards.
+        """
+        async with self._write_lock:
+            await asyncio.to_thread(self._do_clear)
+
     async def close(self) -> None:
         """Flush buffered documents and release the writer.
 

--- a/src/prme/storage/vector_index.py
+++ b/src/prme/storage/vector_index.py
@@ -49,12 +49,19 @@ class VectorIndex:
         embedding_provider: EmbeddingProvider,
         conn_lock: asyncio.Lock | None = None,
         save_interval: int = 64,
+        exact_search: bool = True,
     ) -> None:
         self._conn = conn
         self._index_path = index_path
         self._provider = embedding_provider
         self._write_lock = asyncio.Lock()
         self._conn_lock = conn_lock if conn_lock is not None else asyncio.Lock()
+
+        # Exact (brute-force) vs approximate (HNSW) nearest-neighbor search.
+        # HNSW traversal is order/thread-dependent, so two rebuilds from the
+        # same event log can return different neighbor sets. Exact search is
+        # order-independent and makes retrieval reproducible (issue #45).
+        self._exact_search = exact_search
 
         # Debounced save: the full USearch index file is rewritten on each
         # save, so saving on every insert is O(N^2) total write volume.
@@ -425,7 +432,10 @@ class VectorIndex:
         if fetch_k == 0:
             return None
 
-        matches = self._index.search(query_vector, fetch_k)
+        # exact=True forces brute-force cosine over all vectors, which is
+        # order-independent and reproducible. exact=False uses the HNSW graph
+        # (faster on large corpora, but order/thread-dependent neighbor sets).
+        matches = self._index.search(query_vector, fetch_k, exact=self._exact_search)
         return [
             (int(matches.keys[i]), float(matches.distances[i]))
             for i in range(len(matches.keys))
@@ -440,6 +450,36 @@ class VectorIndex:
         async with self._write_lock:
             await asyncio.to_thread(self._index.save, self._index_path)
             self._unsaved_inserts = 0
+
+    async def clear(self) -> None:
+        """Drop every vector and its metadata, leaving an empty index.
+
+        Resets the in-memory USearch index and the vector_metadata table to
+        a clean slate so the index can be rebuilt from the durable graph
+        nodes (issue #45). The empty index is persisted immediately so a
+        crash mid-rebuild leaves a consistent (empty) artifact rather than a
+        stale one. Caller is responsible for re-indexing afterwards.
+        """
+        async with self._write_lock:
+            async with self._conn_lock:
+                await asyncio.to_thread(self._do_clear)
+
+    def _do_clear(self) -> None:
+        """Synchronous index + metadata reset (runs in thread pool).
+
+        Caller must hold both ``_write_lock`` and ``_conn_lock``.
+        """
+        # Recreate an empty USearch index with the same geometry.
+        self._index = Index(
+            ndim=self._provider.dimension,
+            metric="cos",
+            dtype="f32",
+        )
+        self._conn.execute("DELETE FROM vector_metadata")
+        # The sequence is intentionally not reset: keys stay monotonic so a
+        # rebuild never reuses a key that an in-flight reference might hold.
+        self._index.save(self._index_path)
+        self._unsaved_inserts = 0
 
     async def close(self) -> None:
         """Save index and clean up resources."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from prme.cli import (
     cmd_node,
     cmd_nodes,
     cmd_organize,
+    cmd_rebuild,
     cmd_search,
     cmd_stats,
 )
@@ -490,6 +491,44 @@ async def test_cmd_organize_json(populated_engine, config, capsys):
     data = json.loads(captured)
     assert "jobs_run" in data
     assert "duration_ms" in data
+
+
+@pytest.mark.asyncio
+async def test_cmd_rebuild_table(populated_engine, config, capsys):
+    """rebuild command rebuilds indexes and reports counts."""
+    # Release the populated engine's index locks before the CLI command
+    # opens its own engine on the same pack to run the rebuild.
+    await populated_engine.close()
+
+    args = _make_args(db_path=config.db_path, format="table", batch_size=256)
+    await cmd_rebuild(args)
+
+    captured = capsys.readouterr().out
+    assert "Rebuild complete:" in captured
+    assert "Nodes indexed:" in captured
+
+
+@pytest.mark.asyncio
+async def test_cmd_rebuild_json(populated_engine, config, capsys):
+    """rebuild command outputs valid JSON with index counts."""
+    await populated_engine.close()
+
+    args = _make_args(db_path=config.db_path, format="json", batch_size=256)
+    await cmd_rebuild(args)
+
+    captured = capsys.readouterr().out
+    data = json.loads(captured)
+    assert data["nodes_indexed"] == 3
+    assert data["total_active"] == 3
+    assert data["nodes_skipped"] == 0
+
+
+def test_build_parser_includes_rebuild():
+    """The rebuild subcommand is registered with its handler and flag."""
+    parser = build_parser()
+    args = parser.parse_args(["rebuild", "/tmp/x.duckdb", "--batch-size", "10"])
+    assert args.func is cmd_rebuild
+    assert args.batch_size == 10
 
 
 @pytest.mark.asyncio

--- a/tests/test_determinism_rebuild.py
+++ b/tests/test_determinism_rebuild.py
@@ -1,0 +1,418 @@
+"""Determinism and rebuildability tests (issue #45).
+
+Covers the two least-true documented claims and their fixes:
+
+- Exact (brute-force) vector search makes retrieval order-independent and
+  reproducible, where HNSW traversal is order/thread-dependent.
+- ``MemoryEngine.rebuild_indexes()`` reconstructs the derived vector and
+  lexical indexes from the durable graph nodes without touching the event
+  log or graph, restoring retrieval after the index files are wiped.
+- The determinism validation harness: rebuild the indexes twice from the
+  same pack and assert identical retrieval results for a query suite.
+
+Uses a deterministic hash-based mock embedding (no model download) and
+tmp_path for isolation. All assertions run on the DuckDB backend.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import duckdb
+import pytest
+import pytest_asyncio
+
+from prme.config import PRMEConfig
+from prme.models.nodes import MemoryNode
+from prme.storage.duckpgq_graph import DuckPGQGraphStore
+from prme.storage.engine import MemoryEngine
+from prme.storage.event_store import EventStore
+from prme.storage.lexical_index import LexicalIndex
+from prme.storage.schema import initialize_database
+from prme.storage.vector_index import VectorIndex
+from prme.storage.write_queue import WriteQueue
+from prme.types import LifecycleState, NodeType, Scope
+
+pytestmark = pytest.mark.asyncio
+
+
+class MockEmbeddingProvider:
+    """Deterministic, order-independent embedding from a content hash.
+
+    The same text always maps to the same vector regardless of when or in
+    what order it is embedded, so any non-determinism observed in retrieval
+    comes from the index search strategy rather than the embedding.
+    """
+
+    model_name = "mock-embed"
+    model_version = "mock-1.0"
+    dimension = 16
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        out: list[list[float]] = []
+        for text in texts:
+            digest = hashlib.sha256(text.encode()).digest()
+            out.append([digest[i] / 255.0 for i in range(self.dimension)])
+        return out
+
+
+# --- Fixtures -------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def conn(tmp_path: Path):
+    db_path = str(tmp_path / "memory.duckdb")
+    c = duckdb.connect(db_path)
+    initialize_database(c)
+    yield c
+    c.close()
+
+
+async def _make_engine(
+    tmp_path: Path,
+    conn: duckdb.DuckDBPyConnection,
+    *,
+    exact: bool = True,
+) -> MemoryEngine:
+    """Build a DuckDB MemoryEngine wired with the mock embedding provider."""
+    import asyncio
+
+    conn_lock = asyncio.Lock()
+    event_store = EventStore(conn, conn_lock)
+    graph_store = DuckPGQGraphStore(conn, conn_lock)
+    vector_index = VectorIndex(
+        conn,
+        str(tmp_path / "vectors.usearch"),
+        MockEmbeddingProvider(),
+        conn_lock,
+        save_interval=1,
+        exact_search=exact,
+    )
+    lexical_dir = tmp_path / "lexical_index"
+    lexical_dir.mkdir(exist_ok=True)
+    lexical_index = LexicalIndex(str(lexical_dir))
+    write_queue = WriteQueue(maxsize=256)
+    await write_queue.start()
+
+    return MemoryEngine(
+        conn=conn,
+        event_store=event_store,
+        graph_store=graph_store,
+        vector_index=vector_index,
+        lexical_index=lexical_index,
+        write_queue=write_queue,
+        config=PRMEConfig(),
+    )
+
+
+async def _add_node(
+    engine: MemoryEngine,
+    content: str,
+    user_id: str,
+    *,
+    node_type: NodeType = NodeType.FACT,
+    index: bool = True,
+) -> str:
+    """Create a graph node and (optionally) index it like store() would."""
+    node = MemoryNode(
+        user_id=user_id,
+        node_type=node_type,
+        scope=Scope.PERSONAL,
+        content=content,
+    )
+    await engine._graph_store.create_node(node)
+    node_id = str(node.id)
+    if index:
+        await engine._vector_index.index(node_id, content, user_id)
+        await engine._lexical_index.index(
+            node_id, content, user_id, node_type.value, Scope.PERSONAL.value
+        )
+    return node_id
+
+
+# --- Config plumbing ------------------------------------------------------
+
+
+async def test_exact_search_config_default_on() -> None:
+    """The determinism knob defaults to exact search."""
+    assert PRMEConfig().vector_exact_search is True
+
+
+async def test_exact_flag_threads_into_vector_index(tmp_path: Path, conn) -> None:
+    """The config flag reaches the VectorIndex search strategy."""
+    on = VectorIndex(
+        conn, str(tmp_path / "a.usearch"), MockEmbeddingProvider(), exact_search=True
+    )
+    off = VectorIndex(
+        conn, str(tmp_path / "b.usearch"), MockEmbeddingProvider(), exact_search=False
+    )
+    assert on._exact_search is True
+    assert off._exact_search is False
+
+
+# --- Exact search determinism --------------------------------------------
+
+
+async def test_exact_search_is_order_independent(tmp_path: Path) -> None:
+    """Inserting the same vectors in different orders yields identical results."""
+    contents = [f"fact number {i} about topic alpha" for i in range(12)]
+
+    async def build_and_query(order: list[int], tag: str) -> list[tuple[str, float]]:
+        """Index the same contents in ``order`` and return the ranked result.
+
+        Node ids are fresh uuids per run, so results are mapped back to their
+        content and rounded score: that projection is what must be stable
+        across insertion orders if exact search is order-independent.
+        """
+        c = duckdb.connect(str(tmp_path / f"db-{tag}.duckdb"))
+        initialize_database(c)
+        import asyncio
+
+        lock = asyncio.Lock()
+        graph = DuckPGQGraphStore(c, lock)
+        vidx = VectorIndex(
+            c,
+            str(tmp_path / f"vec-{tag}.usearch"),
+            MockEmbeddingProvider(),
+            lock,
+            save_interval=1,
+            exact_search=True,
+        )
+        id_to_content: dict[str, str] = {}
+        for i in order:
+            node = MemoryNode(
+                user_id="u1",
+                node_type=NodeType.FACT,
+                scope=Scope.PERSONAL,
+                content=contents[i],
+            )
+            await graph.create_node(node)
+            await vidx.index(str(node.id), contents[i], "u1")
+            id_to_content[str(node.id)] = contents[i]
+        results = await vidx.search("topic alpha facts", "u1", k=8)
+        c.close()
+        return [(id_to_content[r["node_id"]], round(r["score"], 6)) for r in results]
+
+    forward = await build_and_query(list(range(12)), "fwd")
+    backward = await build_and_query(list(reversed(range(12))), "bwd")
+
+    # Exact search ranks purely by distance, so the same content set returns
+    # the same (content, score) ranking regardless of insertion order.
+    assert forward
+    assert forward == backward
+
+
+# --- clear() --------------------------------------------------------------
+
+
+async def test_vector_clear_empties_index(tmp_path: Path, conn) -> None:
+    """clear() drops every vector and its metadata."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        await _add_node(engine, "the sky is blue", "u1")
+        await _add_node(engine, "grass is green", "u1")
+        before = conn.execute("SELECT COUNT(*) FROM vector_metadata").fetchone()[0]
+        assert before == 2
+
+        await engine._vector_index.clear()
+
+        after = conn.execute("SELECT COUNT(*) FROM vector_metadata").fetchone()[0]
+        assert after == 0
+        assert len(engine._vector_index._index) == 0
+    finally:
+        await engine.close()
+
+
+async def test_lexical_clear_empties_index(tmp_path: Path, conn) -> None:
+    """clear() removes every lexical document."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        await _add_node(engine, "quick brown fox", "u1")
+        assert await engine._lexical_index.search("fox", "u1", limit=5)
+
+        await engine._lexical_index.clear()
+
+        assert await engine._lexical_index.search("fox", "u1", limit=5) == []
+    finally:
+        await engine.close()
+
+
+# --- rebuild_indexes() ----------------------------------------------------
+
+
+async def test_rebuild_restores_retrieval_after_index_wipe(
+    tmp_path: Path, conn
+) -> None:
+    """Rebuild reconstructs both indexes from the graph after a wipe."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        await _add_node(engine, "Paris is the capital of France", "u1")
+        await _add_node(engine, "Tokyo is the capital of Japan", "u1")
+
+        # Simulate index corruption by wiping both indexes.
+        await engine._vector_index.clear()
+        await engine._lexical_index.clear()
+        assert await engine._vector_index.search("capital of France", "u1", k=5) == []
+
+        summary = await engine.rebuild_indexes()
+
+        assert summary["nodes_indexed"] == 2
+        assert summary["total_active"] == 2
+        vec = await engine._vector_index.search("capital of France", "u1", k=5)
+        assert len(vec) == 2
+        lex = await engine._lexical_index.search("capital", "u1", limit=5)
+        assert len(lex) == 2
+    finally:
+        await engine.close()
+
+
+async def test_rebuild_excludes_superseded_and_archived(
+    tmp_path: Path, conn
+) -> None:
+    """Only active-lifecycle nodes are re-indexed (visibility contract)."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        active = await _add_node(engine, "active fact about widgets", "u1")
+        superseded = await _add_node(engine, "stale fact about widgets", "u1")
+        archived = await _add_node(engine, "archived fact about widgets", "u1")
+
+        # Move two nodes out of active states directly in the graph.
+        await engine._graph_store.update_node(
+            superseded, lifecycle_state=LifecycleState.SUPERSEDED
+        )
+        await engine._graph_store.update_node(
+            archived, lifecycle_state=LifecycleState.ARCHIVED
+        )
+
+        summary = await engine.rebuild_indexes()
+
+        # Three nodes exist, but only the active one is indexed.
+        assert summary["nodes_indexed"] == 1
+        assert summary["total_active"] == 1
+
+        keys = conn.execute(
+            "SELECT node_id FROM vector_metadata ORDER BY node_id"
+        ).fetchall()
+        indexed_ids = {row[0] for row in keys}
+        assert active in indexed_ids
+        assert superseded not in indexed_ids
+        assert archived not in indexed_ids
+    finally:
+        await engine.close()
+
+
+async def test_rebuild_is_nondestructive(tmp_path: Path, conn) -> None:
+    """Rebuild leaves the event log and graph nodes untouched."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        await _add_node(engine, "fact one", "u1")
+        await _add_node(engine, "fact two", "u1")
+
+        nodes_before = conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+        edges_before = conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+        events_before = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+
+        await engine.rebuild_indexes()
+
+        assert conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0] == nodes_before
+        assert conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0] == edges_before
+        assert (
+            conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == events_before
+        )
+    finally:
+        await engine.close()
+
+
+async def test_rebuild_empty_graph(tmp_path: Path, conn) -> None:
+    """Rebuild on a pack with no nodes is a clean no-op."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        summary = await engine.rebuild_indexes()
+        assert summary == {
+            "nodes_indexed": 0,
+            "nodes_skipped": 0,
+            "total_active": 0,
+        }
+    finally:
+        await engine.close()
+
+
+async def test_rebuild_skips_empty_content(tmp_path: Path, conn) -> None:
+    """Active nodes with blank content are skipped and counted."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        await _add_node(engine, "a real fact", "u1", index=False)
+        # Whitespace-only content cannot be embedded.
+        await _add_node(engine, "   ", "u1", index=False)
+
+        summary = await engine.rebuild_indexes()
+
+        assert summary["total_active"] == 2
+        assert summary["nodes_indexed"] == 1
+        assert summary["nodes_skipped"] == 1
+    finally:
+        await engine.close()
+
+
+async def test_rebuild_is_idempotent(tmp_path: Path, conn) -> None:
+    """Running rebuild repeatedly does not duplicate index entries."""
+    engine = await _make_engine(tmp_path, conn)
+    try:
+        await _add_node(engine, "alpha fact", "u1")
+        await _add_node(engine, "beta fact", "u1")
+
+        await engine.rebuild_indexes()
+        first = conn.execute("SELECT COUNT(*) FROM vector_metadata").fetchone()[0]
+        await engine.rebuild_indexes()
+        second = conn.execute("SELECT COUNT(*) FROM vector_metadata").fetchone()[0]
+
+        assert first == 2
+        assert second == 2
+    finally:
+        await engine.close()
+
+
+# --- Determinism validation harness --------------------------------------
+
+
+async def test_rebuild_twice_yields_identical_retrieval(
+    tmp_path: Path, conn
+) -> None:
+    """Two rebuilds from the same pack produce identical retrieval results.
+
+    This is the validation harness from the issue: with exact vector search
+    and deterministic downstream scoring, rebuilding the derived indexes
+    twice from the same durable graph must return the same neighbors in the
+    same order for a query suite.
+    """
+    engine = await _make_engine(tmp_path, conn, exact=True)
+    try:
+        for i in range(20):
+            await _add_node(
+                engine, f"document {i} discussing machine learning topic {i % 4}", "u1"
+            )
+
+        query_suite = [
+            "machine learning topic 0",
+            "document discussing topic 3",
+            "learning",
+        ]
+
+        await engine.rebuild_indexes()
+        first_run = {
+            q: [r["node_id"] for r in await engine._vector_index.search(q, "u1", k=8)]
+            for q in query_suite
+        }
+
+        await engine.rebuild_indexes()
+        second_run = {
+            q: [r["node_id"] for r in await engine._vector_index.search(q, "u1", k=8)]
+            for q in query_suite
+        }
+
+        assert first_run == second_run
+        # And every query returned something to make the assertion meaningful.
+        assert all(first_run[q] for q in query_suite)
+    finally:
+        await engine.close()


### PR DESCRIPTION
## Summary

- Add `vector_exact_search` (default on): exact brute-force cosine search is order-independent, making retrieval reproducible where approximate HNSW traversal was order/thread-dependent. Configurable; documented as DuckDB/USearch-only (pgvector backend uses its own index).
- Add `prme rebuild` (`MemoryEngine.rebuild_indexes()` + CLI): clears the derived vector and lexical indexes and reconstructs them from the active graph nodes in deterministic id order. The event log and graph nodes/edges (the source of truth) are never modified, so the rebuild is non-destructive, safe to re-run, and idempotent. It is the recovery path for index corruption, embedding-model migration, and the index drift a failed eviction leaves behind (#41). Only active-lifecycle nodes are indexed, matching the search visibility contract (#38).
- Add bulk `clear()` to `VectorIndex` and `LexicalIndex`, following the existing per-node delete patterns.

Builds on the current index code rather than against it: rebuild indexes the same active set that #38's lifecycle filter and #41's compaction job already enforce.

**Deferred:** regenerating the graph itself by replaying the raw event log is out of scope — LLM extraction at ingestion is non-deterministic, so a faithful graph replay would be unbounded. This PR rebuilds the derived search indexes from the durable graph, which is the reproducible, non-destructive part of the claim.

## Test plan

- [x] Exact search returns identical results regardless of insertion order, and stable across repeated runs.
- [x] `VectorIndex.clear()` and `LexicalIndex.clear()` empty their indexes.
- [x] Rebuild restores retrieval after both indexes are wiped.
- [x] Rebuild excludes superseded/archived nodes (visibility contract).
- [x] Rebuild leaves events, nodes, and edges untouched (non-destructive).
- [x] Rebuild is idempotent (no duplicate index entries on re-run).
- [x] Empty graph and empty/whitespace content are handled and counted.
- [x] Rebuild twice from the same pack yields identical retrieval (determinism harness).
- [x] CLI `rebuild` table + JSON output and parser registration.
- [x] Full suite green: `uv run pytest -q` → 1193 passed, 25 skipped.

Fixes #45