### PR TITLE
docs: align CLAUDE.md with the shipped architecture and config (#46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PRME (Portable Relational Memory Engine) is a local-first, embeddable memory substrate for LLM-powered systems. It combines event sourcing, graph-based relational modeling, hybrid retrieval, and scheduled memory reorganization. The project is in pre-implementation stage — specs live in `docs/`.
+PRME (Portable Relational Memory Engine) is a local-first, embeddable memory substrate for LLM-powered systems. It combines event sourcing, graph-based relational modeling, hybrid retrieval, and organizer-driven memory reorganization (opportunistic and on-demand; see Organizer). The system is implemented (current release v0.9.0); design specs live in `docs/`.
 
 ## Architecture
 
-Four storage layers behind a unified retrieval API:
+Four storage layers behind a unified retrieval API. The default backend is local DuckDB-based; a PostgreSQL backend (`src/prme/storage/pg/`) is also wired and selected when `database_url` is set.
 
 - **Event Store (DuckDB)** — Append-only immutable event log. All derived structures must be rebuildable from this log.
-- **Graph Store (Kùzu)** — Typed nodes (Entity, Event, Fact, Decision, Preference, Task, Summary) and typed edges with temporal validity windows (`valid_from`/`valid_to`), confidence scores, and provenance references.
-- **Vector Index (HNSW)** — Approximate nearest neighbor search with versioned embeddings (model name, version, dimension tracked per embedding).
-- **Lexical Index (FTS5 or Tantivy)** — Full-text search over event content, facts, and summaries.
+- **Graph Store (DuckDB)** — Typed nodes (Entity, Event, Fact, Decision, Preference, Task, Summary) and typed edges with temporal validity windows (`valid_from`/`valid_to`), confidence scores, and provenance references. Implemented in `src/prme/storage/duckpgq_graph.py` using DuckDB tables with recursive CTEs for traversal (DuckPGQ SQL/PGQ is not available on the supported DuckDB build, so recursive CTEs are the only code path — there is no Kùzu dependency).
+- **Vector Index (USearch HNSW)** — Approximate nearest neighbor search via the `usearch` library (`src/prme/storage/vector_index.py`), persisted to `vectors.usearch`, with versioned embeddings (model name, version, dimension tracked per embedding).
+- **Lexical Index (Tantivy)** — BM25 full-text search via `tantivy-py` (`src/prme/storage/lexical_index.py`), persisted to a `lexical_index/` directory, over event content, facts, and summaries.
 
 ## Key Design Constraints
 
-- **Append-only**: Events must never be overwritten or deleted except by policy-based archival. Conflicting assertions must not silently overwrite prior ones — use supersedence.
+- **Append-only**: Events must never be overwritten or deleted except by policy-based archival. Conflicting assertions must not silently overwrite prior ones — use supersedence. Note: store-time supersedence is gated behind `enable_store_supersedence` (default `False`, `src/prme/config.py`); with the default, `store()` does not supersede and conflict resolution relies on retrieval-time `[LATEST]`/recency markers in the context formatter rather than graph-level supersedence edges. Predicate matching in the supersedence detector is exact-match plus three hardcoded equivalence classes (`src/prme/ingestion/supersedence.py`); paraphrased predicates are not currently superseded.
 - **Deterministic**: Given identical event logs and config, retrieval results must be reproducible. Scoring weights must be configurable and versioned.
-- **Portable artifact**: The memory pack (`events.duckdb`, `graph.kuzu/`, `vectors.bin`, `hnsw.idx`, `manifest.json`) must be copyable, encryptable, and rebuildable.
+- **Portable artifact**: The memory pack — `memory.duckdb` (event store + graph tables), `vectors.usearch` (USearch index), `lexical_index/` (Tantivy directory), and `manifest.json` (encryption/version metadata) — must be copyable, encryptable, and rebuildable. Derived indexes can be regenerated from the durable graph with `prme rebuild`.
 
 ## Hybrid Retrieval Pipeline
 
@@ -29,13 +29,15 @@ Query → intent classification + entity extraction + time detection → candida
 
 Objects progress through: Tentative → Stable → Superseded → Archived. Each object carries: id, type, scope (personal/project/org), confidence, salience, validity window, evidence references, and supersedence pointer.
 
-## Scheduled Organizer
+## Organizer
 
-Periodic jobs handle: salience recalculation, promotion/demotion of assertions, summarization (daily → weekly → monthly), deduplication/entity alias resolution, and policy-based archival with TTL enforcement.
+The organizer (`src/prme/organizer/`, RFC-0015) provides maintenance jobs that handle: salience/confidence recalculation, promotion/demotion of assertions, summarization, deduplication/entity alias resolution, policy-based archival with TTL enforcement, tombstone and index compaction sweeps, and snapshot generation. `ALL_JOBS` currently registers twelve jobs (some are full implementations, some stubs pending future RFCs).
+
+Despite the name "scheduled," there is **no built-in cron or daemon scheduler**. Jobs run in two ways: (1) an opportunistic in-process pass triggered during retrieve/ingest, gated by a cooldown (`opportunistic_cooldown`, default 3600s) and a per-pass time budget (`opportunistic_budget_ms`, default 200ms); and (2) explicit invocation via `prme organize` (optionally `--jobs` and `--budget-ms`). Continuous scheduling, if needed, must be driven by an external cron/timer calling `prme organize`.
 
 ## RFCs
 
-Design specifications live in `docs/` as numbered RFCs (RFC-0000 through RFC-0014). See `docs/INDEX.md` for the full listing. Key RFCs include:
+Design specifications live in `docs/` as numbered RFCs (RFC-0000 through RFC-0015). See `docs/INDEX.md` for the full listing. Key RFCs include:
 
 - **RFC-0000** — Suite overview
 - **RFC-0001** — Core data model
@@ -43,14 +45,26 @@ Design specifications live in `docs/` as numbered RFCs (RFC-0000 through RFC-001
 - **RFC-0003** — Epistemic state model
 - **RFC-0005** — Hybrid retrieval pipeline
 - **RFC-0014** — Portability, sync, and federation
+- **RFC-0015** — Self-organizing memory (organizer execution model)
 
 Always consult the relevant RFC before implementing or modifying a subsystem.
 
-## MVP Phases
+## Configuration Surface
 
-1. Event store, basic graph schema, vector search, hybrid retrieval
-2. Organizer jobs, stable fact promotion, snapshot generation, supersedence handling
-3. Encryption, CLI tooling, evaluation harness, deterministic rebuild validation
+Config is defined as Pydantic models in `src/prme/config.py` and `src/prme/retrieval/config.py` (loaded from `PRME_`-prefixed env vars, `.env`, or direct args). The surface is large (roughly 100 fields across both files). Several parameter defaults are explicitly tagged `[HYPOTHESIS]` in their descriptions — these are reasoned but not yet benchmark-validated and may change. Treat `[HYPOTHESIS]` knobs as provisional and prefer not to depend on their exact values. Notable defaults to be aware of: `enable_store_supersedence=False`, `enable_surprise_gating=False`, and `enable_reranker=False` (the cross-encoder reranker has not improved benchmark scores in practice).
+
+## Storage Backends
+
+- **DuckDB (default)** — local-first; no `database_url` set.
+- **PostgreSQL** — used when `database_url` is set; implemented in `src/prme/storage/pg/`. Its test suite (`tests/test_pg_*.py`) is skipped unless `PRME_TEST_DATABASE_URL` points at a live database, so those tests do not run in the default local/CI environment.
+
+## MVP Phases (delivered)
+
+The originally planned MVP scope is implemented as of v0.9.0:
+
+1. Event store, graph schema, vector search, hybrid retrieval
+2. Organizer jobs, stable fact promotion, snapshot generation, supersedence handling (store-time supersedence opt-in; see Key Design Constraints)
+3. Encryption, CLI tooling, evaluation harness, deterministic rebuild validation (`prme rebuild`)
 
 ## Browser Automation
 


### PR DESCRIPTION
## Summary

- CLAUDE.md described an architecture the code never grew into. This brings it in line with what `main` ships today: graph store is **DuckDB** (recursive CTEs in `storage/duckpgq_graph.py`, no Kùzu anywhere), vector index is **USearch** (`vectors.usearch`), lexical index is **Tantivy** (`lexical_index/`), and the memory pack is `memory.duckdb` + `vectors.usearch` + `lexical_index/` + `manifest.json`.
- Renames "Scheduled Organizer" to "Organizer" and states plainly there is **no cron/daemon scheduler** — jobs run opportunistically in-process (cooldown 3600s, 200ms budget) or on demand via `prme organize`. Also drops the stale "pre-implementation stage" framing (the system is implemented, v0.9.0) and adds Configuration Surface + Storage Backends sections.
- Documents the real defaults the audit flagged: store-time supersedence is opt-in (`enable_store_supersedence=False`, exact + 3 equivalence-class predicate matching), the `[HYPOTHESIS]`-tagged knobs are provisional, the reranker is off and unhelpful, and the PostgreSQL test suite is env-gated. Extends the RFC range to RFC-0015.

This is **documentation only** — no code changed. Where the issue asked me to "decide" on behavior (flip the supersedence default, prune config knobs, ship `prme organize --daemon`), I documented the current reality rather than changing behavior, since those are benchmark-affecting / API-surface / feature decisions that belong to a maintainer, not a docs pass.

### Notes on the issue's claims (some had drifted since it was filed)

- **CLAUDE.md drift (claim 1)** — confirmed and fixed. Additionally found the RFC range was stale (RFC-0015 exists) and the "pre-implementation" wording was wrong; both corrected.
- **No scheduler (claim 2)** — confirmed; the organizer now has **12** registered jobs (PR #41 added `index_compaction`). Documented accurately rather than shipping a daemon.
- **Supersedence off by default (claim 3)** — confirmed; line numbers have shifted to `config.py:280-288` and `ingestion/supersedence.py:31-35`. Documented; default left unchanged (flipping it changes benchmarked behavior).
- **`[HYPOTHESIS]` knobs (claim 4)** — the count has grown since filing: there are now **19** tagged fields (16 in `config.py`, 3 in `retrieval/config.py`), not 14. Documented the category rather than pruning the public config surface. Note: the reranker fields are not themselves tagged `[HYPOTHESIS]`; I documented the reranker's empirically-harmful default instead.
- **PostgreSQL tests (claim 5)** — partially stale: it's **19** tests across 5 files (not 25), and they're skipped **conditionally** (skipped unless `PRME_TEST_DATABASE_URL` is set), not permanently disabled. The backend is real (`storage/pg/`). Documented as such.

## Test plan

- [x] `uv run pytest -q` — 1193 passed, 25 skipped (PostgreSQL, env-gated). The single teardown error seen in the full parallel run (`test_cli.py::test_cmd_nodes_filter_type`, `OSError: Directory not empty`) is a pre-existing flaky temp-dir cleanup race unrelated to this change; the test and the full `tests/test_cli.py` module pass in isolation (52 passed).
- [x] No code paths touched — change is confined to `CLAUDE.md`.

### How to verify the doc now matches reality

1. `grep -ri kuzu src/` returns nothing; `src/prme/storage/duckpgq_graph.py` confirms DuckDB + recursive CTEs.
2. `src/prme/config.py` defaults: `db_path=./memory.duckdb`, `vector_path=./vectors.usearch`, `lexical_path=./lexical_index`.
3. `prme organize` and `prme rebuild` exist in the CLI; there is no `--daemon` flag and no cron/APScheduler import.
4. `enable_store_supersedence` defaults `False`; `PREDICATE_EQUIVALENCES` in `ingestion/supersedence.py` has exactly 3 classes.

Fixes #46