### PR TITLE
fix(extraction): pass model to client.create() so bedrock provider works

### DIFF
--- a/src/prme/ingestion/extraction.py
+++ b/src/prme/ingestion/extraction.py
@@ -130,8 +130,12 @@ class InstructorExtractionProvider:
 
     Args:
         provider_string: Provider/model string (e.g., 'openai/gpt-4o-mini',
-            'anthropic/claude-3-5-sonnet-20241022', 'ollama/llama3.2').
-        model: Optional model override (unused, reserved for future use).
+            'anthropic/claude-3-5-sonnet-20241022', 'ollama/llama3.2',
+            'bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0').
+        model: Optional model id passed to client.create(). Required for the
+            'bedrock' provider, whose instructor client is NOT pre-bound to a
+            model by from_provider(). When None, the model is derived from the
+            provider_string.
         max_retries: Number of instructor retries for schema validation failures.
         timeout: Timeout in seconds per extraction call.
     """
@@ -174,6 +178,22 @@ class InstructorExtractionProvider:
         """Return the full provider/model string."""
         return self._provider_string
 
+    def _resolve_model_id(self) -> str | None:
+        """Model id to pass to client.create().
+
+        instructor.from_provider() pre-binds the model into the client for most
+        providers (openai, anthropic, ...), but NOT for 'bedrock' -- there the
+        model string is only used to pick a mode, so client.create() raises
+        "Missing required parameter: modelId" unless we pass the model
+        explicitly. Passing it for every provider is safe: create()'s model
+        overrides the client default when both are set.
+        """
+        if self._model:
+            return self._model
+        if "/" in self._provider_string:
+            return self._provider_string.split("/", 1)[1]
+        return None
+
     async def extract(
         self, content: str, *, role: str = "user"
     ) -> ExtractionResult:
@@ -190,14 +210,18 @@ class InstructorExtractionProvider:
         """
         try:
             client = self._ensure_client()
-            result = await client.create(
-                response_model=ExtractionResult,
-                messages=[
+            create_kwargs: dict = {
+                "response_model": ExtractionResult,
+                "messages": [
                     {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
                     {"role": role, "content": content},
                 ],
-                max_retries=self._max_retries,
-            )
+                "max_retries": self._max_retries,
+            }
+            model_id = self._resolve_model_id()
+            if model_id:
+                create_kwargs["model"] = model_id
+            result = await client.create(**create_kwargs)
             return result
         except Exception:
             logger.error(
@@ -226,6 +250,7 @@ def create_extraction_provider(
     provider_string = f"{config.provider}/{config.model}"
     return InstructorExtractionProvider(
         provider_string,
+        model=config.model,
         max_retries=config.max_retries,
         timeout=config.timeout,
     )

--- a/tests/test_extraction_model_passing.py
+++ b/tests/test_extraction_model_passing.py
@@ -1,0 +1,66 @@
+"""Regression: InstructorExtractionProvider must pass model= to client.create().
+
+instructor.from_provider() pre-binds the model for most providers, but NOT for
+'bedrock' -- there client.create() raises "Missing required parameter: modelId"
+unless the model is passed explicitly. These tests lock in that behavior so the
+bedrock provider keeps working (and so create_extraction_provider forwards the
+configured model).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from prme.config import ExtractionConfig
+from prme.ingestion.extraction import (
+    InstructorExtractionProvider,
+    create_extraction_provider,
+)
+from prme.ingestion.schema import ExtractionResult
+
+BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+
+def _mock_client():
+    client = AsyncMock()
+    client.create = AsyncMock(return_value=ExtractionResult())
+    return client
+
+
+async def test_extract_passes_model_to_create_for_bedrock():
+    provider = InstructorExtractionProvider(
+        f"bedrock/{BEDROCK_MODEL}", model=BEDROCK_MODEL
+    )
+    client = _mock_client()
+    with patch.object(provider, "_ensure_client", return_value=client):
+        await provider.extract("Alex has a Blue Cross PPO plan.", role="user")
+
+    client.create.assert_awaited_once()
+    assert client.create.await_args.kwargs["model"] == BEDROCK_MODEL
+
+
+async def test_model_derived_from_provider_string_when_not_given():
+    # No explicit model= -> derive it from the provider string (split on first '/').
+    provider = InstructorExtractionProvider(f"bedrock/{BEDROCK_MODEL}")
+    assert provider._resolve_model_id() == BEDROCK_MODEL
+
+    client = _mock_client()
+    with patch.object(provider, "_ensure_client", return_value=client):
+        await provider.extract("Alex has a Blue Cross PPO plan.", role="user")
+    assert client.create.await_args.kwargs["model"] == BEDROCK_MODEL
+
+
+async def test_factory_forwards_configured_model():
+    config = ExtractionConfig(provider="bedrock", model=BEDROCK_MODEL)
+    provider = create_extraction_provider(config)
+    assert isinstance(provider, InstructorExtractionProvider)
+    assert provider._resolve_model_id() == BEDROCK_MODEL
+
+
+async def test_openai_model_still_passed():
+    # Passing model for non-bedrock providers is safe and expected.
+    provider = InstructorExtractionProvider("openai/gpt-4o-mini", model="gpt-4o-mini")
+    client = _mock_client()
+    with patch.object(provider, "_ensure_client", return_value=client):
+        await provider.extract("hello", role="user")
+    assert client.create.await_args.kwargs["model"] == "gpt-4o-mini"


### PR DESCRIPTION
## Problem

`instructor.from_provider()` pre-binds the model into the returned client for most providers (openai, anthropic, …), but **not** for `bedrock` — there the model string is only used to pick a mode. `InstructorExtractionProvider.extract()` called `client.create()` without a `model=`, so the bedrock provider failed 100% with `Missing required parameter in input: "modelId"`.

## Fix

- `extract()` now passes `model=` to `client.create()` — from `self._model`, or derived from the provider string (`split("/", 1)`). Safe for all providers: `create()`'s model overrides the client default.
- `create_extraction_provider()` forwards `config.model` to the provider.
- Adds `tests/test_extraction_model_passing.py` (mocked client — no live LLM).

Verified live against AWS Bedrock (Sonnet 4): extraction now returns entities/facts/relationships instead of erroring.

## Context

Unblocks KindHealth **KAK-677** — the agent's long-term memory (PRME) phase-2 extraction was silently disabled on ECS because it defaulted to `openai/gpt-4o-mini` with no key. Pointing PRME at bedrock only works once `create()` receives the model.