### PR TITLE
Audit follow-up: retrieval filter leaks, retrieval latency, node ownership

### DIFF
--- a/memory_bank/AUDIT-2026-08-04.md
+++ b/memory_bank/AUDIT-2026-08-04.md
@@ -1,0 +1,192 @@
+# PRME v0.10.0 — Audit (2026-08-04)
+
+Follow-up to [AUDIT-2026-06-11-SUMMARY.md](AUDIT-2026-06-11-SUMMARY.md), which
+covered v0.9.0. Every finding below was verified against the working tree at
+commit `b3e2ffc` (v0.10.0, clean). Baseline health: `uv run pytest -q` gives
+**1197 passed, 25 skipped** in 109s.
+
+## What v0.10.0 closed
+
+The June audit's mechanical backlog is largely done and verified in code:
+
+- REST API auth (bearer token), loopback-only default bind, CORS off unless
+  origins are pinned, sanitized 500 responses (`api/app.py`, `api/routes.py`).
+- Stored content sanitized before entering the prompt, with a data-vs-instruction
+  notice (`retrieval/context_formatter.py:96-197`). The implementation documents
+  its own limits honestly.
+- Batched `get_nodes()` on all three fan-out paths, SQL-pushed pinned/session
+  predicates, debounced USearch saves, batched tantivy commits.
+- Deterministic vector search (`exact_search=True` by default) and
+  `prme rebuild`. The determinism choice is cheap at realistic scale: measured
+  0.09 ms/query at 1k vectors, 0.71 ms at 10k, 7.0 ms at 100k (384-dim, k=50)
+  versus 0.07/0.15/0.22 ms for HNSW. No reason to revisit this before ~1M nodes.
+- Index eviction on supersedence/archival, auto-promote cursor fix, formatter
+  token budget and dedup.
+
+Eleven of the twelve registered organizer jobs are real implementations; only
+`centrality_boost` is still a stub.
+
+## Finding 1 (High, correctness + isolation): stages after Stage 4 re-introduce
+## nodes that Stage 4 removed
+
+`retrieval/pipeline.py` filters candidates for scope, bi-temporal window, and
+epistemic/lifecycle state — and then four later stages append nodes to the
+result set without re-applying any of those filters. All four are on by default.
+
+| Stage | Where | What it skips |
+|---|---|---|
+| Aggregation keyword scan | `pipeline.py:248-281` | `scope`, temporal window |
+| Entity-focused expansion | `pipeline.py:312-359` | `scope`, temporal window |
+| Session context expansion | `pipeline.py:474-490`, `session_context.py:82-86` | `scope`, `knowledge_at`, `event_time_*`, epistemic filter |
+| Cross-scope hints | `pipeline.py:492-544` | bi-temporal filters, epistemic filter |
+
+Verified empirically with throwaway probes against a real engine:
+
+- `retrieve("How many times was Project Falcon mentioned?", scope=Scope.PROJECT)`
+  returned a `PERSONAL`-scope node on the `LEXICAL` path. Scope isolation
+  (RFC-0004) is bypassed because those two lexical scans call
+  `lexical_index.search(...)` without the `scope=` argument the main candidate
+  path passes.
+- A `HYPOTHETICAL` node in the same session as a matching hit came back on the
+  `SESSION_CONTEXT` path and its text appeared in the packed bundle, though
+  `filtering.py` documents HYPOTHETICAL as excluded in DEFAULT mode.
+- With `knowledge_at` set to a cutoff, a node created *after* the cutoff came
+  back on the `SESSION_CONTEXT` path. The bi-temporal snapshot guarantee
+  (issue #21) does not hold.
+- Cross-scope hints returned a `HYPOTHETICAL` node.
+
+Lifecycle is the one filter that survives by accident: session expansion calls
+`graph_store.query_nodes()`, which defaults to active states, and archived
+content is now evicted from the lexical/vector indexes, so SUPERSEDED/ARCHIVED
+content did not leak in testing. That is a defense the code does not state and
+should not rely on.
+
+Fix: run `filter_epistemic` (and the bi-temporal predicates) once, after every
+candidate-producing stage rather than in the middle; forward `scope` into the
+two lexical scans and into the session-node query. The existing scope tests pass
+because they never exercise a proper-noun or aggregation query.
+
+## Finding 2 (High, security): tenant isolation is still open (issue #35)
+
+Unchanged since June and now the only remaining High from that audit:
+
+- `engine.get_node(node_id)` takes no `user_id`; `promote`/`archive`/`reinforce`
+  have no ownership check.
+- `GET /v1/nodes` with `user_id` omitted returns every user's nodes; the
+  node-detail route passes `include_superseded=True`, so archived content is
+  reachable by ID.
+- MCP tools accept a caller-supplied `user_id` (`mcp/server.py:116, 174, 237`),
+  so a prompt-injected agent can read or plant memories under another user.
+
+The API-auth work landed, so binding the authenticated principal to `user_id`
+server-side is now a small change rather than a blocked one.
+
+## Finding 3 (High, performance): `dateparser` costs 70 ms per retrieve and
+## blocks the event loop
+
+`query_analysis._extract_temporal_signals` calls
+`dateparser.search.search_dates(query, settings=...)` with no `languages`
+argument, so dateparser attempts language detection across its full locale set
+on every query. Profiling 20 retrieves over a 500-node store:
+
+```
+100 calls  cumtime 3.918s  pipeline.retrieve
+ 20 calls  cumtime 3.321s  query_analysis.analyze_query -> _extract_temporal_signals
+```
+
+85% of retrieval wall time is date parsing. Isolated measurement: 70.0 ms/query
+as shipped versus 0.3 ms/query with `languages=["en"]` — a 233x difference.
+End-to-end effect, same corpus and query set, monkeypatched:
+
+```
+baseline (dateparser as shipped)   p50  109 ms
+with languages=['en']              p50   67 ms
+```
+
+Three separate problems in one call site:
+
+1. No `languages` pin. English is already assumed elsewhere (tantivy English
+   stemming, the hardcoded English stopword list in the aggregation scan), so
+   `languages=["en"]` with a config override is consistent, not a regression.
+2. No cheap pre-gate. Most queries contain no temporal cue at all; a regex
+   pre-check for digits or a known temporal word would skip the call entirely.
+3. `analyze_query` is `async def` but runs this synchronously, so it blocks the
+   event loop for the whole duration. Under the REST API, concurrent retrievals
+   serialize behind it. With `enable_query_reformulation` on, the pipeline pays
+   it once more per alternate query.
+
+## Finding 4 (Medium, performance): the organizer runs inside the user's
+## retrieve call
+
+`engine.retrieve()` awaits `self._maintenance_runner.maybe_run()` before
+returning (`engine.py:1322-1326`). With `opportunistic_enabled=True` and a
+200 ms budget, one retrieval per cooldown window pays the full maintenance cost
+on the user-visible path — observed as a 1086 ms max against a 146 ms p50 in the
+same run. The pass has no dependency on the response, so it should be scheduled
+rather than awaited.
+
+## Finding 5 (High, credibility): the published numbers are three releases stale
+## and internally inconsistent
+
+`README.md:11-48` presents LongMemEval 92.5% and LoCoMo 79.0% as current. Those
+strings were last touched in `ec9981e` (**v0.4.0**, 2026-03). The newest file in
+`benchmarks/results/` is `locomo_v24_multihop.json`, from the v0.9.0 cycle. No
+benchmark run exists for v0.10.0 at all.
+
+Internal inconsistencies in the same table:
+
+- "Abstention | 65% (30/30)" — 30/30 is 100%.
+- The category numerators sum to 448/470 = 95.3%, not the 92.5% headline.
+- "944 tests passing" — the suite is 1197.
+- "11 organizer jobs" — `ALL_JOBS` registers 12.
+- "All benchmarks are deterministic given the same retrieval results and
+  generation model" — the June audit measured 5-8 questions of run-to-run flip
+  noise.
+
+## Finding 6 (High, credibility): the measurement fix shipped but was never used
+
+Issue #44 delivered the infrastructure: a separate `judge_model`, a file-backed
+`VerdictCache`, multi-run scoring. But `judge_provider`/`judge_model` default to
+`None` and fall back to the generation model
+(`benchmarks/llm_judge.py:194-205`), so out of the box the same model still
+generates and judges. The re-baseline those tools were built for has not been
+run.
+
+The harness also still carries the inflation machinery the June audit flagged:
+
+- `benchmarks/locomo.py:698-736, 865-893` still ingests the dataset's own
+  `observation` annotations as nodes.
+- `benchmarks/locomo.py:930` and `benchmarks/longmemeval.py:890-899` still call
+  the harness-local `reformulate_query`, even though the product now ships
+  `enable_query_reformulation` — so the benchmark measures a path a user still
+  cannot reproduce with config alone.
+- `GENERATION_SYSTEM_PROMPT` still contains worked examples copied from specific
+  LoCoMo items: the grandma-in-Sweden inference and the "3 kids" count
+  (`llm_judge.py:50-56`).
+- Benchmarks still ingest through `store()`; `ingest()` remains unmeasured.
+
+## Finding 7 (Medium, API gaps)
+
+- **`RetrievalMode` is unreachable.** `grep` finds no `retrieval_mode` on
+  `engine.retrieve`, `client.py`, the REST API, MCP, or the CLI. EXPLICIT mode —
+  the documented way to see superseded and hypothetical nodes (RFC-0003 S8) —
+  can only be reached by constructing `RetrievalPipeline` directly.
+- **`store()` returns an event ID, but every lifecycle method takes a node ID**
+  (`engine.py:514-516`). There is no `get_node_by_event()`; callers must
+  `query_nodes()` and match `evidence_refs` by hand. This cost time during this
+  audit and will cost every integrator the same.
+- **`[HYPOTHESIS]` fields grew**: 16 in `config.py` plus 3 in
+  `retrieval/config.py`, up from 14 in June. Untested defaults are still
+  accumulating in the public config surface.
+- **`enable_store_supersedence` is still `False`.** CLAUDE.md's append-only
+  supersedence constraint remains unmet by the default configuration.
+
+## Suggested order
+
+1. Finding 3 (one-line pin plus a pre-gate and a thread hop; ~40% latency cut).
+2. Finding 1 (filter re-application; correctness and isolation).
+3. Finding 4 (schedule the organizer pass instead of awaiting it).
+4. Finding 2 / issue #35 (bind identity server-side now that auth exists).
+5. Findings 5 and 6 together: pin a judge, drop the harness-only machinery and
+   the copied prompt examples, run the re-baseline, and republish the README
+   table from that run. Everything about "are we improving?" depends on it.

--- a/src/prme/config.py
+++ b/src/prme/config.py
@@ -384,6 +384,19 @@ class PRMEConfig(BaseSettings):
         ),
     )
 
+    # Temporal parsing cost control (issue #61)
+    temporal_languages: list[str] = Field(
+        default=["en"],
+        description=(
+            "Languages used to parse date expressions out of query text. "
+            "dateparser costs ~70ms per query when it has to detect the "
+            "language itself versus ~0.3ms with a single language pinned, and "
+            "that detection was 85% of retrieval latency. Set to an empty list "
+            "to restore dateparser's auto-detection for multilingual queries "
+            "at that cost."
+        ),
+    )
+
     # Dual-stream ingestion (issue #25)
     materialization_queue_size: int = Field(
         default=500,

--- a/src/prme/organizer/maintenance.py
+++ b/src/prme/organizer/maintenance.py
@@ -12,6 +12,7 @@ of decayed nodes.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timedelta, timezone
@@ -35,17 +36,72 @@ class MaintenanceRunner:
         self._engine = engine
         self._config = config
         self._last_maintained_at: float = 0.0  # epoch seconds, 0 = never run
+        self._task: asyncio.Task[MaintenanceResult | None] | None = None
 
-    async def maybe_run(self) -> MaintenanceResult | None:
-        """Check cooldown and run maintenance if due. Returns None if skipped."""
+    def _is_due(self) -> bool:
+        """Whether a maintenance pass is enabled and past its cooldown."""
         if not self._config.opportunistic_enabled:
+            return False
+        # First call always runs (last_maintained_at == 0)
+        if self._last_maintained_at <= 0:
+            return True
+        elapsed = time.monotonic() - self._last_maintained_at
+        return elapsed >= self._config.opportunistic_cooldown
+
+    def schedule(self) -> None:
+        """Start a maintenance pass in the background if one is due.
+
+        Callers on the user-visible path (retrieve, ingest) use this instead
+        of awaiting ``maybe_run()``: the pass produces nothing the response
+        depends on, and its time budget would otherwise land on the caller's
+        latency (issue #62). At most one pass runs at a time, and the cooldown
+        is marked at launch so a burst of concurrent calls cannot stampede.
+        """
+        if self._task is not None and not self._task.done():
+            return
+        if not self._is_due():
+            return
+
+        self._last_maintained_at = time.monotonic()
+        self._task = asyncio.create_task(self._run_scheduled())
+
+    async def _run_scheduled(self) -> MaintenanceResult | None:
+        """Background wrapper: never lets a failure escape as a task error."""
+        try:
+            result = await self._run_maintenance()
+            self._last_maintained_at = time.monotonic()
+            return result
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Opportunistic maintenance failed; continuing normally",
+                exc_info=True,
+            )
+            self._last_maintained_at = time.monotonic()
             return None
 
-        now = time.monotonic()
-        elapsed = now - self._last_maintained_at
+    async def drain(self) -> None:
+        """Await an in-flight background pass, if any.
 
-        # First call always runs (last_maintained_at == 0)
-        if self._last_maintained_at > 0 and elapsed < self._config.opportunistic_cooldown:
+        Called on engine close so a scheduled pass finishes (or surfaces its
+        failure) before the write queue and connections go away.
+        """
+        task = self._task
+        if task is None or task.done():
+            return
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def maybe_run(self) -> MaintenanceResult | None:
+        """Check cooldown and run maintenance if due. Returns None if skipped.
+
+        Runs the pass inline. ``schedule()`` is the non-blocking variant used
+        on the hot path.
+        """
+        if not self._is_due():
             return None
 
         try:

--- a/src/prme/retrieval/pipeline.py
+++ b/src/prme/retrieval/pipeline.py
@@ -56,6 +56,33 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _apply_bitemporal_filters(
+    candidates: list[RetrievalCandidate],
+    knowledge_at: datetime | None,
+    event_time_from: datetime | None,
+    event_time_to: datetime | None,
+) -> list[RetrievalCandidate]:
+    """Drop candidates outside the bi-temporal window (issue #21).
+
+    Operates on the MemoryNode attached to each candidate, so it works
+    regardless of which stage produced the candidate. Nodes without an
+    ``event_time`` fall back to ``created_at`` (ingestion time).
+    """
+    if knowledge_at is not None:
+        candidates = [c for c in candidates if c.node.created_at <= knowledge_at]
+    if event_time_from is not None:
+        candidates = [
+            c for c in candidates
+            if (c.node.event_time or c.node.created_at) >= event_time_from
+        ]
+    if event_time_to is not None:
+        candidates = [
+            c for c in candidates
+            if (c.node.event_time or c.node.created_at) <= event_time_to
+        ]
+    return candidates
+
+
 class RetrievalPipeline:
     """Hybrid retrieval pipeline orchestrator.
 
@@ -179,6 +206,11 @@ class RetrievalPipeline:
             normalized_scope = scope
         # else: None means "all scopes, no filter"
 
+        # String form used by the lexical/vector index scope filters.
+        scope_values = (
+            [s.value for s in normalized_scope] if normalized_scope else None
+        )
+
         # Resolve effective configuration.
         effective_weights = weights if weights is not None else self._scoring_weights
         effective_packing_config = self._packing_config
@@ -249,9 +281,14 @@ class RetrievalPipeline:
             # Run all term searches concurrently, then resolve the unique
             # hits with a single batched node fetch (instead of sequential
             # searches with one get_node round trip per hit).
+            # The scope filter is forwarded here as it is on the main lexical
+            # path: without it this scan pulls other scopes' nodes straight
+            # into the primary result list (issue #60).
             term_results = await asyncio.gather(
                 *[
-                    self._lexical_index.search(term, user_id=user_id, limit=50)
+                    self._lexical_index.search(
+                        term, user_id=user_id, limit=50, scope=scope_values,
+                    )
                     for term in search_terms
                 ],
                 return_exceptions=True,
@@ -320,7 +357,9 @@ class RetrievalPipeline:
             entity_names = analysis.entities[:3]
             entity_results = await asyncio.gather(
                 *[
-                    self._lexical_index.search(name, user_id=user_id, limit=20)
+                    self._lexical_index.search(
+                        name, user_id=user_id, limit=20, scope=scope_values,
+                    )
                     for name in entity_names
                 ],
                 return_exceptions=True,
@@ -388,27 +427,9 @@ class RetrievalPipeline:
 
         # --- Stage 3.5: Bi-temporal Post-Filtering (issue #21) ---
         # Applied after candidate generation and before epistemic filtering.
-        # These filters operate on the MemoryNode fields attached to each
-        # candidate, so they work regardless of which backend generated them.
-        if knowledge_at is not None:
-            candidates = [
-                c for c in candidates
-                if c.node.created_at <= knowledge_at
-            ]
-        if event_time_from is not None:
-            # Include nodes whose event_time >= event_time_from.
-            # Nodes without event_time fall back to created_at (ingestion time).
-            candidates = [
-                c for c in candidates
-                if (c.node.event_time or c.node.created_at) >= event_time_from
-            ]
-        if event_time_to is not None:
-            # Include nodes whose event_time <= event_time_to.
-            # Nodes without event_time fall back to created_at (ingestion time).
-            candidates = [
-                c for c in candidates
-                if (c.node.event_time or c.node.created_at) <= event_time_to
-            ]
+        candidates = _apply_bitemporal_filters(
+            candidates, knowledge_at, event_time_from, event_time_to
+        )
 
         # --- Stage 4: Epistemic Filtering ---
         filtered, excluded = filter_epistemic(
@@ -481,12 +502,28 @@ class RetrievalPipeline:
         # where a question is retrieved but not its adjacent answer.
         if effective_packing_config.session_context_window > 0:
             try:
-                scored = await expand_session_context(
+                expanded = await expand_session_context(
                     scored,
                     graph_store=self._graph_store,
                     user_id=user_id,
                     config=effective_packing_config,
+                    scope=normalized_scope,
                 )
+                # Expansion appends adjacent turns that never went through
+                # Stages 3.5 and 4, so the same predicates run once more over
+                # the expanded set (issue #60). Nodes that already passed are
+                # unaffected; only the newly appended ones can be dropped.
+                if len(expanded) != len(scored):
+                    expanded = _apply_bitemporal_filters(
+                        expanded, knowledge_at, event_time_from, event_time_to
+                    )
+                    expanded, late_excluded = filter_epistemic(
+                        expanded,
+                        analysis.retrieval_mode,
+                        unverified_threshold=self._unverified_confidence_threshold,
+                    )
+                    excluded.extend(late_excluded)
+                scored = expanded
             except Exception:
                 logger.warning(
                     "Session context expansion failed; continuing without expansion",
@@ -531,6 +568,17 @@ class RetrievalPipeline:
                     c for c in hint_candidates
                     if c.node.scope.value not in primary_scope_values
                 ]
+                # Crossing the scope boundary is the point of this pass; the
+                # bi-temporal window and the epistemic filter still apply
+                # (issue #60).
+                hint_candidates = _apply_bitemporal_filters(
+                    hint_candidates, knowledge_at, event_time_from, event_time_to
+                )
+                hint_candidates, _ = filter_epistemic(
+                    hint_candidates,
+                    analysis.retrieval_mode,
+                    unverified_threshold=self._unverified_confidence_threshold,
+                )
                 # Score the hints using the same weights and timestamp.
                 if hint_candidates:
                     scored_hints, _ = score_and_rank(

--- a/src/prme/retrieval/pipeline.py
+++ b/src/prme/retrieval/pipeline.py
@@ -22,6 +22,7 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -42,7 +43,7 @@ from prme.retrieval.models import (
     RetrievalResponse,
 )
 from prme.retrieval.packing import pack_context
-from prme.retrieval.query_analysis import analyze_query
+from prme.retrieval.query_analysis import DEFAULT_TEMPORAL_LANGUAGES, analyze_query
 from prme.retrieval.scoring import score_and_rank
 from prme.retrieval.session_context import expand_session_context
 from prme.types import EdgeType, LifecycleState, RepresentationLevel, RetrievalMode, Scope
@@ -85,6 +86,7 @@ class RetrievalPipeline:
         query_reformulation_count: int = 2,
         query_reformulation_provider: str = "openai",
         query_reformulation_model: str = "gpt-4o-mini",
+        temporal_languages: Sequence[str] | None = DEFAULT_TEMPORAL_LANGUAGES,
     ) -> None:
         self._graph_store = graph_store
         self._vector_index = vector_index
@@ -101,6 +103,7 @@ class RetrievalPipeline:
         self._query_reformulation_count = query_reformulation_count
         self._query_reformulation_provider = query_reformulation_provider
         self._query_reformulation_model = query_reformulation_model
+        self._temporal_languages = temporal_languages
 
         # Lazy-init cross-encoder reranker when enabled.
         self._reranker = None
@@ -197,6 +200,7 @@ class RetrievalPipeline:
             time_from=time_from,
             time_to=time_to,
             retrieval_mode=retrieval_mode,
+            languages=self._temporal_languages,
         )
 
         # Determine effective temporal window: explicit params take priority
@@ -670,6 +674,7 @@ class RetrievalPipeline:
                 time_from=time_from,
                 time_to=time_to,
                 retrieval_mode=retrieval_mode,
+                languages=self._temporal_languages,
             )
             alt_candidates, _ = await generate_candidates(
                 alt_analysis,

--- a/src/prme/retrieval/query_analysis.py
+++ b/src/prme/retrieval/query_analysis.py
@@ -8,7 +8,9 @@ matching only -- no blocking LLM calls per RFC-0005 S3.
 from __future__ import annotations
 
 import logging
+import asyncio
 import re
+from collections.abc import Sequence
 from datetime import datetime
 from uuid import uuid4
 
@@ -72,6 +74,49 @@ _KNOWN_TEMPORAL_WORDS = frozenset({
     "nov", "dec", "mon", "tue", "wed", "thu", "fri", "sat", "sun",
 })
 
+# --- dateparser cost control (issue #61) ---
+#
+# search_dates() is the single most expensive call in the retrieval hot path:
+# 70ms per query with no language pin (dateparser tries its full locale set)
+# versus 0.3ms pinned to English. Two guards keep it off the critical path:
+# a language pin, and a cue pre-gate so queries with no date-like token skip
+# the call entirely.
+
+# Default language set for temporal parsing. English is already assumed
+# elsewhere in the pipeline (tantivy English stemming, the English stopword
+# list in the aggregation scan). Pass languages=None to restore dateparser's
+# auto-detection at its original cost.
+DEFAULT_TEMPORAL_LANGUAGES: tuple[str, ...] = ("en",)
+
+# Words that can appear in a multi-word temporal expression without being a
+# temporal match on their own ("two weeks ago", "the day after tomorrow").
+# The pre-gate needs them so it stays a superset of what dateparser finds.
+_RELATIVE_TIME_WORDS = frozenset({
+    "now", "next", "past", "coming", "upcoming", "tonight", "weekend",
+    "day", "days", "night", "nights", "week", "weeks", "month", "months",
+    "year", "years", "hour", "hours", "minute", "minutes", "second",
+    "seconds", "morning", "afternoon", "evening", "midnight", "noon",
+    "decade", "decades", "fortnight", "quarter", "century",
+})
+
+# A query is worth handing to dateparser only if it contains a digit or one of
+# these words. Every signal the extractor keeps satisfies one of the two:
+# matches with digits, single-word matches restricted to _KNOWN_TEMPORAL_WORDS,
+# and multi-word matches, which need a unit or qualifier word to parse.
+_TEMPORAL_GATE_WORDS = _KNOWN_TEMPORAL_WORDS | _RELATIVE_TIME_WORDS
+
+_DIGIT_RE = re.compile(r"\d")
+_WORD_RE = re.compile(r"[a-z]+")
+
+
+def _has_temporal_cue(query: str) -> bool:
+    """Cheap pre-check for whether a query can contain a date expression."""
+    if _DIGIT_RE.search(query):
+        return True
+    return any(
+        word in _TEMPORAL_GATE_WORDS for word in _WORD_RE.findall(query.lower())
+    )
+
 
 def _classify_intent(query: str, has_temporal_signals: bool) -> QueryIntent:
     """Classify query intent using keyword/pattern matching.
@@ -121,17 +166,29 @@ def _extract_entities(query: str) -> list[str]:
     return entities
 
 
-def _extract_temporal_signals(query: str) -> list[dict]:
+def _extract_temporal_signals(
+    query: str,
+    languages: Sequence[str] | None = DEFAULT_TEMPORAL_LANGUAGES,
+) -> list[dict]:
     """Extract temporal expressions from the query via dateparser.
 
     Returns a list of dicts with keys: type, value, resolved.
     Falls back to empty list if dateparser is unavailable or fails.
+
+    Args:
+        query: Raw query text.
+        languages: Languages to parse against. None restores dateparser's
+            own language detection, which costs ~70ms per query.
     """
+    if not _has_temporal_cue(query):
+        return []
+
     try:
         from dateparser.search import search_dates
 
         results = search_dates(
             query,
+            languages=list(languages) if languages else None,
             settings={
                 "RETURN_AS_TIMEZONE_AWARE": True,
                 "TIMEZONE": "UTC",
@@ -186,6 +243,7 @@ async def analyze_query(
     time_from: datetime | None = None,
     time_to: datetime | None = None,
     retrieval_mode: RetrievalMode = RetrievalMode.DEFAULT,
+    languages: Sequence[str] | None = DEFAULT_TEMPORAL_LANGUAGES,
 ) -> QueryAnalysis:
     """Analyze a query into intent, entities, and temporal signals.
 
@@ -197,13 +255,19 @@ async def analyze_query(
         time_from: Explicit start of temporal window (overrides extraction).
         time_to: Explicit end of temporal window (overrides extraction).
         retrieval_mode: Retrieval mode controlling epistemic filtering.
+        languages: Languages for temporal parsing. None restores dateparser's
+            own language detection at its original cost.
 
     Returns:
         QueryAnalysis with classified intent, extracted entities,
         temporal signals, and a unique request_id.
     """
-    # Extract temporal signals from query text.
-    temporal_signals = _extract_temporal_signals(query)
+    # Extract temporal signals from query text. dateparser is CPU-bound and
+    # can take milliseconds on a long query, so it runs off the event loop
+    # (issue #61) -- otherwise concurrent retrievals serialize behind it.
+    temporal_signals = await asyncio.to_thread(
+        _extract_temporal_signals, query, languages
+    )
     has_temporal_signals = len(temporal_signals) > 0
 
     # Classify intent (temporal detection feeds into intent classification).

--- a/src/prme/retrieval/session_context.py
+++ b/src/prme/retrieval/session_context.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 from prme.retrieval.config import PackingConfig
 from prme.retrieval.models import RetrievalCandidate
 
+from prme.types import Scope
+
 if TYPE_CHECKING:
     from prme.models.nodes import MemoryNode
     from prme.storage.graph_store import GraphStore
@@ -29,6 +31,7 @@ async def expand_session_context(
     graph_store: GraphStore,
     user_id: str,
     config: PackingConfig,
+    scope: list[Scope] | None = None,
 ) -> list[RetrievalCandidate]:
     """Expand top-scored candidates with adjacent session turns.
 
@@ -48,6 +51,9 @@ async def expand_session_context(
         graph_store: GraphStore for querying session nodes.
         user_id: User ID for scoping graph queries.
         config: PackingConfig with session context settings.
+        scope: Optional scope filter, forwarded to the session-node query so
+            expansion cannot pull in adjacent turns from another scope
+            (issue #60). None means no scope filter.
 
     Returns:
         Expanded candidate list with context nodes interleaved after
@@ -82,6 +88,7 @@ async def expand_session_context(
         all_nodes = await graph_store.query_nodes(
             user_id=user_id,
             session_ids=list(session_triggers.keys()),
+            scopes=scope if scope else None,
             limit=2000,
         )
         for n in all_nodes:

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -1370,21 +1370,71 @@ class MemoryEngine:
 
     # --- Node Operations (delegated to GraphStore) ---
 
+    async def _owned_node(
+        self,
+        node_id: str,
+        user_id: str | None,
+        *,
+        include_superseded: bool = True,
+    ) -> MemoryNode | None:
+        """Fetch a node, enforcing ownership when a user is supplied.
+
+        Node-ID operations are otherwise unscoped: knowing an ID is enough to
+        read or mutate another user's memory (issue #35). Passing ``user_id``
+        makes the operation fail exactly as it would for a nonexistent node,
+        so a caller cannot learn that an ID they do not own exists -- RFC-0004
+        S6 forbids revealing the existence of objects outside the caller's
+        namespace.
+
+        Returns None when the node is missing or owned by someone else.
+        """
+        node = await self._graph_store.get_node(
+            node_id, include_superseded=include_superseded
+        )
+        if node is None:
+            return None
+        if user_id is not None and node.user_id != user_id:
+            logger.warning(
+                "Ownership check rejected node %s for user %r",
+                node_id,
+                user_id,
+            )
+            return None
+        return node
+
+    async def _require_owned(self, node_id: str, user_id: str) -> MemoryNode:
+        """Return a node the user owns, or raise the standard not-found error.
+
+        The message matches the graph store's own wording so an unauthorized
+        mutation is indistinguishable from one against a nonexistent node.
+        """
+        node = await self._owned_node(node_id, user_id)
+        if node is None:
+            raise ValueError(f"Node {node_id} not found")
+        return node
+
     async def get_node(
         self,
         node_id: str,
         *,
         include_superseded: bool = False,
+        user_id: str | None = None,
     ) -> MemoryNode | None:
         """Retrieve a node by ID.
 
         Args:
             node_id: String UUID of the node.
             include_superseded: If True, return superseded/archived nodes.
+            user_id: When given, the node is returned only if this user owns
+                it. A node owned by anyone else reads as not found.
 
         Returns:
             The MemoryNode if found and visible, None otherwise.
         """
+        if user_id is not None:
+            return await self._owned_node(
+                node_id, user_id, include_superseded=include_superseded
+            )
         return await self._graph_store.get_node(
             node_id, include_superseded=include_superseded
         )
@@ -1441,15 +1491,20 @@ class MemoryEngine:
 
     # --- Lifecycle Transitions (delegated to GraphStore) ---
 
-    async def promote(self, node_id: str) -> None:
+    async def promote(self, node_id: str, *, user_id: str | None = None) -> None:
         """Promote a tentative node to stable.
 
         Args:
             node_id: Node to promote.
+            user_id: When given, the promotion only applies to a node this
+                user owns; anyone else's node raises as if it did not exist.
 
         Raises:
-            ValueError: If the transition is invalid.
+            ValueError: If the transition is invalid, or the node is missing
+                or owned by another user.
         """
+        if user_id is not None:
+            await self._require_owned(node_id, user_id)
         await self._graph_store.promote(node_id)
 
     async def supersede(
@@ -1458,6 +1513,7 @@ class MemoryEngine:
         new_node_id: str,
         *,
         evidence_id: str | None = None,
+        user_id: str | None = None,
     ) -> None:
         """Mark a node as superseded by another.
 
@@ -1465,10 +1521,17 @@ class MemoryEngine:
             old_node_id: Node being replaced.
             new_node_id: Replacement node.
             evidence_id: Optional event ID for provenance.
+            user_id: When given, both nodes must belong to this user. A
+                supersedence edge that crosses users is never legitimate: it
+                would let one user's memory retire another's.
 
         Raises:
-            ValueError: If the transition is invalid.
+            ValueError: If the transition is invalid, or either node is
+                missing or owned by another user.
         """
+        if user_id is not None:
+            await self._require_owned(old_node_id, user_id)
+            await self._require_owned(new_node_id, user_id)
         await self._graph_store.supersede(
             old_node_id, new_node_id, evidence_id=evidence_id
         )
@@ -1477,15 +1540,20 @@ class MemoryEngine:
         # event log remains the source of truth, so this is reconstructable.
         await self._evict_from_indexes(old_node_id)
 
-    async def archive(self, node_id: str) -> None:
+    async def archive(self, node_id: str, *, user_id: str | None = None) -> None:
         """Archive a node (terminal state).
 
         Args:
             node_id: Node to archive.
+            user_id: When given, the archival only applies to a node this
+                user owns; anyone else's node raises as if it did not exist.
 
         Raises:
-            ValueError: If the transition is invalid.
+            ValueError: If the transition is invalid, or the node is missing
+                or owned by another user.
         """
+        if user_id is not None:
+            await self._require_owned(node_id, user_id)
         await self._graph_store.archive(node_id)
         # Archived content is not retrievable, so drop it from the indexes.
         await self._evict_from_indexes(node_id)
@@ -1692,6 +1760,8 @@ class MemoryEngine:
         self,
         node_id: str,
         evidence_id: str | None = None,
+        *,
+        user_id: str | None = None,
     ) -> None:
         """Reinforce a memory node, boosting its confidence and salience.
 
@@ -1703,14 +1773,17 @@ class MemoryEngine:
         Args:
             node_id: The node to reinforce.
             evidence_id: Optional event ID to append to evidence_refs.
+            user_id: When given, only a node this user owns is reinforced;
+                anyone else's node raises as if it did not exist.
 
         Raises:
-            ValueError: If the node does not exist.
+            ValueError: If the node does not exist, or is owned by another
+                user when user_id is given.
         """
         from datetime import timezone
         from uuid import UUID
 
-        node = await self._graph_store.get_node(node_id, include_superseded=True)
+        node = await self._owned_node(node_id, user_id)
         if node is None:
             raise ValueError(f"Node {node_id!r} not found")
 

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -1072,9 +1072,11 @@ class MemoryEngine:
                 scope=scope,
             )
 
-        # Opportunistic maintenance (RFC-0015 Layer 2)
+        # Opportunistic maintenance (RFC-0015 Layer 2). Scheduled rather
+        # than awaited: nothing in the response depends on it, so its time
+        # budget must not land on the caller's latency (issue #62).
         if self._maintenance_runner:
-            await self._maintenance_runner.maybe_run()
+            self._maintenance_runner.schedule()
 
         return event_id
 
@@ -1321,9 +1323,11 @@ class MemoryEngine:
             include_cross_scope=include_cross_scope,
         )
 
-        # Opportunistic maintenance (RFC-0015 Layer 2)
+        # Opportunistic maintenance (RFC-0015 Layer 2). Scheduled rather
+        # than awaited: nothing in the response depends on it, so its time
+        # budget must not land on the caller's latency (issue #62).
         if self._maintenance_runner:
-            await self._maintenance_runner.maybe_run()
+            self._maintenance_runner.schedule()
 
         return result
 
@@ -2082,6 +2086,16 @@ class MemoryEngine:
         if self._closed:
             return
         self._closed = True
+
+        # Let any scheduled maintenance pass finish before the write queue
+        # and connections it uses go away (issue #62).
+        if self._maintenance_runner is not None:
+            try:
+                await self._maintenance_runner.drain()
+            except Exception:
+                logger.warning(
+                    "Error draining opportunistic maintenance", exc_info=True
+                )
 
         # Shutdown pipeline first (cancel background extraction tasks)
         if self._pipeline is not None:

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -311,6 +311,7 @@ class MemoryEngine:
             query_reformulation_count=config.query_reformulation_count,
             query_reformulation_provider=config.extraction.provider,
             query_reformulation_model=config.extraction.model,
+            temporal_languages=config.temporal_languages,
         )
 
         # Run epistemic backfill migration for existing nodes
@@ -424,6 +425,7 @@ class MemoryEngine:
             query_reformulation_count=config.query_reformulation_count,
             query_reformulation_provider=config.extraction.provider,
             query_reformulation_model=config.extraction.model,
+            temporal_languages=config.temporal_languages,
         )
 
         # Run epistemic backfill migration

--- a/tests/test_maintenance_scheduling.py
+++ b/tests/test_maintenance_scheduling.py
@@ -1,0 +1,190 @@
+"""Tests for background opportunistic maintenance scheduling (issue #62).
+
+The pass used to be awaited inside retrieve()/ingest(), putting its full time
+budget on the caller's latency. It now runs as a tracked background task that
+engine.close() drains.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from prme.config import OrganizerConfig, PRMEConfig
+from prme.organizer.maintenance import MaintenanceRunner
+from prme.organizer.models import MaintenanceResult
+from prme.storage.engine import MemoryEngine
+
+
+class _StubEngine:
+    """Minimal stand-in: the runner only needs an object to hold on to."""
+
+
+@pytest.fixture
+def runner():
+    return MaintenanceRunner(_StubEngine(), OrganizerConfig())
+
+
+async def test_schedule_returns_before_the_pass_completes(runner, monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow():
+        started.set()
+        await release.wait()
+        return MaintenanceResult()
+
+    monkeypatch.setattr(runner, "_run_maintenance", _slow)
+
+    t0 = time.perf_counter()
+    runner.schedule()
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+
+    assert elapsed_ms < 50, "schedule() must not wait for the pass"
+    await started.wait()
+    assert runner._task is not None and not runner._task.done()
+
+    release.set()
+    await runner.drain()
+    assert runner._task.done()
+
+
+async def test_schedule_does_not_stack_passes(runner, monkeypatch):
+    release = asyncio.Event()
+    calls = 0
+
+    async def _slow():
+        nonlocal calls
+        calls += 1
+        await release.wait()
+        return MaintenanceResult()
+
+    monkeypatch.setattr(runner, "_run_maintenance", _slow)
+
+    runner.schedule()
+    first_task = runner._task
+    await asyncio.sleep(0)
+    runner.schedule()
+    runner.schedule()
+
+    assert runner._task is first_task
+
+    release.set()
+    await runner.drain()
+    assert calls == 1
+
+
+async def test_schedule_respects_the_cooldown(runner, monkeypatch):
+    calls = 0
+
+    async def _fast():
+        nonlocal calls
+        calls += 1
+        return MaintenanceResult()
+
+    monkeypatch.setattr(runner, "_run_maintenance", _fast)
+
+    runner.schedule()
+    await runner.drain()
+    runner.schedule()
+    await runner.drain()
+
+    assert calls == 1, "second pass is inside the cooldown window"
+
+
+async def test_schedule_is_a_noop_when_disabled(monkeypatch):
+    runner = MaintenanceRunner(
+        _StubEngine(), OrganizerConfig(opportunistic_enabled=False)
+    )
+
+    async def _fail():
+        raise AssertionError("maintenance must not run when disabled")
+
+    monkeypatch.setattr(runner, "_run_maintenance", _fail)
+
+    runner.schedule()
+    await runner.drain()
+    assert runner._task is None
+
+
+async def test_background_failure_does_not_escape(runner, monkeypatch, caplog):
+    async def _boom():
+        raise RuntimeError("maintenance exploded")
+
+    monkeypatch.setattr(runner, "_run_maintenance", _boom)
+
+    runner.schedule()
+    await runner.drain()
+
+    assert runner._task is not None and runner._task.exception() is None
+    assert runner._last_maintained_at > 0
+
+
+async def test_drain_without_a_scheduled_pass(runner):
+    await runner.drain()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Engine integration
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def engine():
+    with tempfile.TemporaryDirectory(prefix="prme_maint_") as d:
+        tmp = Path(d)
+        lexical_path = tmp / "lexical_index"
+        lexical_path.mkdir()
+        eng = await MemoryEngine.create(PRMEConfig(
+            db_path=str(tmp / "memory.duckdb"),
+            vector_path=str(tmp / "vectors.usearch"),
+            lexical_path=str(lexical_path),
+        ))
+        yield eng
+        if not eng._closed:
+            await eng.close()
+
+
+async def test_retrieve_does_not_await_maintenance(engine, monkeypatch):
+    release = asyncio.Event()
+    ran = asyncio.Event()
+
+    async def _slow():
+        ran.set()
+        await release.wait()
+        return MaintenanceResult()
+
+    monkeypatch.setattr(engine._maintenance_runner, "_run_maintenance", _slow)
+
+    await engine.store("a note about the parser", user_id="alice")
+    await engine.retrieve("parser", user_id="alice")
+
+    # The pass is in flight, not finished, and retrieve() already returned.
+    await ran.wait()
+    assert not engine._maintenance_runner._task.done()
+
+    release.set()
+    await engine.close()
+
+
+async def test_close_drains_the_scheduled_pass(engine, monkeypatch):
+    finished = False
+
+    async def _pass():
+        nonlocal finished
+        await asyncio.sleep(0.05)
+        finished = True
+        return MaintenanceResult()
+
+    monkeypatch.setattr(engine._maintenance_runner, "_run_maintenance", _pass)
+
+    await engine.store("a note about the parser", user_id="alice")
+    await engine.retrieve("parser", user_id="alice")
+    await engine.close()
+
+    assert finished, "close() must wait for the in-flight maintenance pass"

--- a/tests/test_node_ownership.py
+++ b/tests/test_node_ownership.py
@@ -1,0 +1,148 @@
+"""Tests for engine-level node ownership checks (issue #35).
+
+Node-ID operations were unscoped: knowing an ID was enough to read or mutate
+another user's memory. Passing ``user_id`` now makes a foreign node behave
+exactly like a missing one, so a caller cannot use the difference between
+"denied" and "not found" to learn that an ID exists (RFC-0004 S6).
+
+Omitting ``user_id`` keeps the previous single-user behaviour, which the
+organizer and CLI rely on.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from prme.config import PRMEConfig
+from prme.storage.engine import MemoryEngine
+from prme.types import NodeType
+
+
+@pytest_asyncio.fixture
+async def engine():
+    with tempfile.TemporaryDirectory(prefix="prme_owner_") as d:
+        tmp = Path(d)
+        lexical_path = tmp / "lexical_index"
+        lexical_path.mkdir()
+        eng = await MemoryEngine.create(PRMEConfig(
+            db_path=str(tmp / "memory.duckdb"),
+            vector_path=str(tmp / "vectors.usearch"),
+            lexical_path=str(lexical_path),
+        ))
+        yield eng
+        await eng.close()
+
+
+async def _node_id_for(engine: MemoryEngine, user_id: str) -> str:
+    nodes = await engine.query_nodes(user_id=user_id, limit=1)
+    assert nodes, f"expected a stored node for {user_id}"
+    return str(nodes[0].id)
+
+
+@pytest_asyncio.fixture
+async def alice_node(engine):
+    await engine.store(
+        "Alice's private salary figure is 123456.",
+        user_id="alice", node_type=NodeType.FACT,
+    )
+    return await _node_id_for(engine, "alice")
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+async def test_get_node_returns_own_node(engine, alice_node):
+    node = await engine.get_node(alice_node, user_id="alice")
+    assert node is not None and node.user_id == "alice"
+
+
+async def test_get_node_hides_another_users_node(engine, alice_node):
+    assert await engine.get_node(alice_node, user_id="mallory") is None
+
+
+async def test_get_node_hides_another_users_archived_node(engine, alice_node):
+    await engine.archive(alice_node)
+    assert await engine.get_node(
+        alice_node, include_superseded=True, user_id="mallory"
+    ) is None
+
+
+async def test_get_node_without_user_id_is_unchanged(engine, alice_node):
+    node = await engine.get_node(alice_node)
+    assert node is not None and node.user_id == "alice"
+
+
+async def test_missing_and_foreign_nodes_are_indistinguishable(engine, alice_node):
+    missing = await engine.get_node(
+        "00000000-0000-0000-0000-000000000000", user_id="mallory"
+    )
+    foreign = await engine.get_node(alice_node, user_id="mallory")
+    assert missing is foreign is None
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
+
+
+async def test_promote_rejects_another_users_node(engine, alice_node):
+    with pytest.raises(ValueError, match="not found"):
+        await engine.promote(alice_node, user_id="mallory")
+
+    node = await engine.get_node(alice_node)
+    assert node.lifecycle_state.value == "tentative"
+
+
+async def test_archive_rejects_another_users_node(engine, alice_node):
+    with pytest.raises(ValueError, match="not found"):
+        await engine.archive(alice_node, user_id="mallory")
+
+    node = await engine.get_node(alice_node, include_superseded=True)
+    assert node.lifecycle_state.value != "archived"
+
+
+async def test_reinforce_rejects_another_users_node(engine, alice_node):
+    before = await engine.get_node(alice_node)
+
+    with pytest.raises(ValueError, match="not found"):
+        await engine.reinforce(alice_node, user_id="mallory")
+
+    after = await engine.get_node(alice_node)
+    assert after.reinforcement_boost == before.reinforcement_boost
+
+
+async def test_supersede_rejects_a_cross_user_pair(engine, alice_node):
+    await engine.store("Mallory's own note.", user_id="mallory")
+    mallory_node = await _node_id_for(engine, "mallory")
+
+    with pytest.raises(ValueError, match="not found"):
+        await engine.supersede(alice_node, mallory_node, user_id="mallory")
+
+    node = await engine.get_node(alice_node, include_superseded=True)
+    assert node.lifecycle_state.value != "superseded"
+
+
+async def test_owner_can_still_mutate(engine, alice_node):
+    await engine.promote(alice_node, user_id="alice")
+    node = await engine.get_node(alice_node)
+    assert node.lifecycle_state.value == "stable"
+
+    await engine.reinforce(alice_node, user_id="alice")
+    reinforced = await engine.get_node(alice_node)
+    assert reinforced.reinforcement_boost > 0
+
+    await engine.archive(alice_node, user_id="alice")
+    archived = await engine.get_node(alice_node, include_superseded=True)
+    assert archived.lifecycle_state.value == "archived"
+
+
+async def test_mutations_without_user_id_are_unchanged(engine, alice_node):
+    await engine.promote(alice_node)
+    node = await engine.get_node(alice_node)
+    assert node.lifecycle_state.value == "stable"

--- a/tests/test_query_analysis.py
+++ b/tests/test_query_analysis.py
@@ -1,0 +1,175 @@
+"""Tests for query analysis Stage 1, focused on temporal extraction.
+
+Covers the dateparser cost guards from issue #61: the language pin and the
+cue pre-gate must cut the call without losing any temporal signal the
+pipeline previously produced.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prme.retrieval import query_analysis
+from prme.retrieval.query_analysis import (
+    DEFAULT_TEMPORAL_LANGUAGES,
+    _extract_temporal_signals,
+    _has_temporal_cue,
+    analyze_query,
+)
+from prme.types import QueryIntent
+
+
+# ---------------------------------------------------------------------------
+# Pre-gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "what did we decide last week",
+        "the meeting on March 5 2026",
+        "two weeks ago we shipped the parser",
+        "what happened yesterday",
+        "the day after tomorrow",
+        "notes from 2026-03-05",
+        "call me Friday",
+        "budget for Q3 in 3 months",
+    ],
+)
+def test_pre_gate_passes_temporal_queries(query):
+    assert _has_temporal_cue(query) is True
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "what is my dentist's name",
+        "roadmap for project falcon",
+        "who works on the platform team",
+        "how many times was Sweden mentioned",
+        "",
+    ],
+)
+def test_pre_gate_rejects_non_temporal_queries(query):
+    assert _has_temporal_cue(query) is False
+
+
+def test_pre_gate_skips_dateparser_entirely(monkeypatch):
+    """A query with no date-like token must not reach dateparser at all."""
+    import dateparser.search
+
+    calls: list[str] = []
+
+    def _spy(text, **kwargs):
+        calls.append(text)
+        return None
+
+    monkeypatch.setattr(dateparser.search, "search_dates", _spy)
+
+    assert _extract_temporal_signals("roadmap for project falcon") == []
+    assert calls == []
+
+    _extract_temporal_signals("roadmap for project falcon last week")
+    assert calls == ["roadmap for project falcon last week"]
+
+
+# ---------------------------------------------------------------------------
+# Language pin
+# ---------------------------------------------------------------------------
+
+
+def test_languages_are_pinned_by_default(monkeypatch):
+    import dateparser.search
+
+    seen: dict = {}
+
+    def _spy(text, **kwargs):
+        seen.update(kwargs)
+        return None
+
+    monkeypatch.setattr(dateparser.search, "search_dates", _spy)
+
+    _extract_temporal_signals("what did we decide last week")
+    assert seen["languages"] == list(DEFAULT_TEMPORAL_LANGUAGES)
+
+
+def test_empty_languages_restores_auto_detection(monkeypatch):
+    import dateparser.search
+
+    seen: dict = {}
+
+    def _spy(text, **kwargs):
+        seen.update(kwargs)
+        return None
+
+    monkeypatch.setattr(dateparser.search, "search_dates", _spy)
+
+    _extract_temporal_signals("what did we decide last week", languages=[])
+    assert seen["languages"] is None
+
+
+# ---------------------------------------------------------------------------
+# Signals still resolve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "what did we decide last week",
+        "the meeting on March 5 2026",
+        "what happened yesterday",
+        "two weeks ago we shipped the parser",
+    ],
+)
+def test_temporal_signals_still_extracted(query):
+    signals = _extract_temporal_signals(query)
+    assert signals, f"expected a temporal signal for {query!r}"
+    assert all(s["resolved"] is not None for s in signals)
+
+
+def test_single_word_false_positives_still_filtered():
+    # "me" parses as Monday and "may" as May in dateparser; both must be
+    # dropped, and neither should survive the pre-gate change.
+    assert _extract_temporal_signals("tell me about the parser") == []
+
+
+async def test_analyze_query_resolves_window_from_text():
+    analysis = await analyze_query("what did we decide last week")
+    assert analysis.intent == QueryIntent.TEMPORAL
+    assert analysis.time_from is not None
+    assert analysis.time_to is not None
+
+
+async def test_analyze_query_without_temporal_cue():
+    analysis = await analyze_query("roadmap for project falcon")
+    assert analysis.temporal_signals == []
+    assert analysis.time_from is None
+    assert analysis.time_to is None
+
+
+async def test_explicit_window_survives_the_pre_gate():
+    """Explicit time_from/time_to must apply even when the text has no cue."""
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    analysis = await analyze_query(
+        "roadmap for project falcon", time_from=start, time_to=end
+    )
+    assert analysis.time_from == start
+    assert analysis.time_to == end
+
+
+async def test_analyze_query_forwards_languages(monkeypatch):
+    seen: dict = {}
+
+    def _spy(query, languages=DEFAULT_TEMPORAL_LANGUAGES):
+        seen["languages"] = languages
+        return []
+
+    monkeypatch.setattr(query_analysis, "_extract_temporal_signals", _spy)
+
+    await analyze_query("what happened last week", languages=["fr"])
+    assert seen["languages"] == ["fr"]

--- a/tests/test_retrieval_filter_leaks.py
+++ b/tests/test_retrieval_filter_leaks.py
@@ -1,0 +1,170 @@
+"""Regression tests for issue #60.
+
+Stages that run after Stage 4 (session context expansion, cross-scope hints)
+and the two supplementary lexical scans used to append nodes without
+re-applying the scope, bi-temporal, and epistemic filters. Each test here
+drives the full engine and asserts a specific leak stays closed.
+
+The existing scope tests do not cover these paths because they never issue a
+proper-noun query (which triggers entity expansion) or an aggregation query
+(which triggers the exhaustive keyword scan).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from prme.config import PRMEConfig
+from prme.storage.engine import MemoryEngine
+from prme.types import EpistemicType, Scope
+
+
+@pytest.fixture
+def leak_config():
+    with tempfile.TemporaryDirectory(prefix="prme_leak_") as d:
+        tmp = Path(d)
+        lexical_path = tmp / "lexical_index"
+        lexical_path.mkdir()
+        yield PRMEConfig(
+            db_path=str(tmp / "memory.duckdb"),
+            vector_path=str(tmp / "vectors.usearch"),
+            lexical_path=str(lexical_path),
+        )
+
+
+@pytest_asyncio.fixture
+async def engine(leak_config):
+    eng = await MemoryEngine.create(leak_config)
+    yield eng
+    await eng.close()
+
+
+async def test_entity_and_aggregation_scans_respect_scope(engine):
+    """A scoped aggregation query must not return other scopes' nodes."""
+    await engine.store(
+        "Project Falcon ships in November.",
+        user_id="bob", session_id="s1", scope=Scope.PROJECT,
+    )
+    await engine.store(
+        "Project Falcon is my secret personal side hustle.",
+        user_id="bob", session_id="s2", scope=Scope.PERSONAL,
+    )
+
+    # Proper noun plus "how many" exercises both entity expansion and the
+    # exhaustive aggregation keyword scan.
+    response = await engine.retrieve(
+        "How many times was Project Falcon mentioned?",
+        user_id="bob",
+        scope=Scope.PROJECT,
+    )
+
+    assert response.results, "expected the in-scope node to be retrieved"
+    assert all(c.node.scope == Scope.PROJECT for c in response.results)
+
+
+async def test_session_expansion_respects_epistemic_filter(engine):
+    """HYPOTHETICAL neighbours must not ride into the bundle on expansion."""
+    await engine.store(
+        "The quarterly budget review is scheduled for Tuesday.",
+        user_id="alice", session_id="s1",
+    )
+    await engine.store(
+        "Hypothetically we could move the whole company to Mars next year.",
+        user_id="alice", session_id="s1",
+        epistemic_type=EpistemicType.HYPOTHETICAL,
+    )
+
+    response = await engine.retrieve("quarterly budget review", user_id="alice")
+
+    assert response.results
+    assert all(
+        c.node.epistemic_type != EpistemicType.HYPOTHETICAL
+        for c in response.results
+    )
+    assert "Mars" not in str(response.bundle.model_dump())
+
+
+async def test_session_expansion_respects_knowledge_at(engine):
+    """A point-in-time query must not surface post-cutoff session turns."""
+    await engine.store(
+        "The quarterly budget review is scheduled for Tuesday.",
+        user_id="alice", session_id="s1",
+    )
+    cutoff = datetime.now(timezone.utc)
+    await asyncio.sleep(0.05)
+    await engine.store(
+        "Correction: the budget review moved to Friday.",
+        user_id="alice", session_id="s1",
+    )
+
+    response = await engine.retrieve(
+        "quarterly budget review", user_id="alice", knowledge_at=cutoff,
+    )
+
+    assert response.results
+    assert all(c.node.created_at <= cutoff for c in response.results)
+
+
+async def test_session_expansion_respects_scope(engine):
+    """Expansion must not pull adjacent turns from outside the scope filter."""
+    await engine.store(
+        "Project Falcon ships in November.",
+        user_id="bob", session_id="shared", scope=Scope.PROJECT,
+    )
+    await engine.store(
+        "Unrelated personal note about the November holidays.",
+        user_id="bob", session_id="shared", scope=Scope.PERSONAL,
+    )
+
+    response = await engine.retrieve(
+        "shipping date", user_id="bob", scope=Scope.PROJECT,
+    )
+
+    assert all(c.node.scope == Scope.PROJECT for c in response.results)
+
+
+async def test_cross_scope_hints_respect_epistemic_filter(engine):
+    """Hints cross the scope boundary; they do not cross the epistemic one."""
+    await engine.store(
+        "Project Falcon ships in November.",
+        user_id="bob", session_id="p1", scope=Scope.PROJECT,
+    )
+    await engine.store(
+        "Hypothetically Project Falcon might get cancelled and rebranded.",
+        user_id="bob", session_id="p2", scope=Scope.PERSONAL,
+        epistemic_type=EpistemicType.HYPOTHETICAL,
+    )
+
+    response = await engine.retrieve(
+        "Project Falcon shipping date", user_id="bob", scope=Scope.PROJECT,
+    )
+
+    assert all(
+        c.node.epistemic_type != EpistemicType.HYPOTHETICAL
+        for c in response.cross_scope_hints
+    )
+
+
+async def test_unscoped_retrieval_still_sees_every_scope(engine):
+    """The scope forwarding must not filter when no scope was requested."""
+    await engine.store(
+        "Project Falcon ships in November.",
+        user_id="bob", session_id="s1", scope=Scope.PROJECT,
+    )
+    await engine.store(
+        "Project Falcon is my personal side hustle.",
+        user_id="bob", session_id="s2", scope=Scope.PERSONAL,
+    )
+
+    response = await engine.retrieve(
+        "How many times was Project Falcon mentioned?", user_id="bob",
+    )
+
+    scopes = {c.node.scope for c in response.results}
+    assert scopes == {Scope.PROJECT, Scope.PERSONAL}

--- a/tests/test_self_organizing_integration.py
+++ b/tests/test_self_organizing_integration.py
@@ -433,6 +433,9 @@ class TestOpportunisticMaintenance:
 
             # Trigger retrieve to fire opportunistic maintenance
             await engine.retrieve("promotion test", user_id="test-user")
+            # Maintenance runs in the background now (issue #62); wait
+            # for the scheduled pass before asserting on its effects.
+            await engine._maintenance_runner.drain()
 
             # Check the node was promoted
             node_after = await engine.get_node(node_id, include_superseded=True)
@@ -477,6 +480,9 @@ class TestOpportunisticMaintenance:
 
             # Trigger retrieve to fire opportunistic maintenance
             await engine.retrieve("archival test", user_id="test-user")
+            # Maintenance runs in the background now (issue #62); wait
+            # for the scheduled pass before asserting on its effects.
+            await engine._maintenance_runner.drain()
 
             # Check the node was archived
             node_after = await engine.get_node(node_id, include_superseded=True)
@@ -563,6 +569,9 @@ class TestOpportunisticMaintenance:
                 "Another message to trigger maintenance",
                 user_id="test-user",
             )
+            # Maintenance runs in the background now (issue #62); wait
+            # for the scheduled pass before asserting on its effects.
+            await engine._maintenance_runner.drain()
 
             # Check promotion happened
             node_after = await engine.get_node(node_id, include_superseded=True)


### PR DESCRIPTION
Work from the 2026-08 audit of v0.10.0. The report is in `memory_bank/AUDIT-2026-08-04.md`; the issues it produced are #60 through #67.

Every finding here was reproduced against a running engine before being fixed, and each fix was verified with the same probe afterwards.

## Retrieval correctness (#60)

Four stages append candidates after the pipeline has already filtered for scope, the bi-temporal window, and epistemic state, and none of them re-applied those filters. All four are on by default. Confirmed leaks: a PERSONAL node returned under `scope=PROJECT`, a HYPOTHETICAL node in the packed bundle, a post-cutoff node returned under `knowledge_at`, and HYPOTHETICAL nodes in cross-scope hints.

Scope is now forwarded to the aggregation keyword scan, the entity-focused expansion, and the session-node query. The bi-temporal and epistemic filters run again over the session-expanded set and over cross-scope hints. Stage 3.5 moved into `_apply_bitemporal_filters` so one predicate set serves every caller.

## Latency (#61, #62)

`dateparser.search_dates()` ran without a `languages` argument and accounted for 85 percent of retrieval wall time: 70.0 ms per query against 0.3 ms with English pinned. It is now pinned (configurable via `temporal_languages`), skipped entirely for queries with no date-like token, and run off the event loop instead of blocking it.

The opportunistic organizer pass was awaited inside `retrieve()` and `ingest()`, putting its 200 ms budget on the user-visible path. It now runs as a tracked background task that `close()` drains.

Measured on the same 500-node corpus and query set:

```
retrieve p50        146 ms -> 71 ms
retrieve max       1086 ms -> 114 ms
aggregation p50     185 ms -> 75 ms
```

## Tenant isolation, storage half (#35)

`get_node`, `promote`, `archive`, `reinforce`, and `supersede` accept an optional `user_id` and refuse to act on another user's node. A foreign node reads exactly like a missing one, so the response cannot be used to probe for IDs, per RFC-0004 section 6.

## Tests

1247 passing, 25 skipped, up from 1197. Four new files: `test_query_analysis.py` (25), `test_retrieval_filter_leaks.py` (6), `test_maintenance_scheduling.py` (8), `test_node_ownership.py` (11). Three existing integration tests were updated to drain the now-asynchronous maintenance pass before asserting on its effects.

## Deliberately not included

- **`#35` is not closed.** The engine enforcement is opt-in and nothing passes `user_id` yet. The REST API still calls `get_node` bare, `GET /v1/nodes` still returns every user's nodes when the parameter is omitted, and MCP still accepts a caller-supplied `user_id`. Those need an identity resolver, since the API currently has no principal to pass.
- **Lexical candidates still ignore `time_from` and `time_to`** on the main path, since the lexical index has no temporal filter. Closing that would drop lexical hits on every temporal query, an accuracy change that needs a trustworthy baseline first (#64).
- **The organizer tenancy bug (#66)** is untouched: `organize(user_id=)` is inert and the deduplicate and alias_resolve jobs scan across tenants.
