### PR TITLE
Scope organizer jobs to a tenant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ Objects progress through: Tentative → Stable → Superseded → Archived. Each
 
 The organizer (`src/prme/organizer/`, RFC-0015) provides maintenance jobs that handle: salience/confidence recalculation, promotion/demotion of assertions, summarization, deduplication/entity alias resolution, policy-based archival with TTL enforcement, tombstone and index compaction sweeps, and snapshot generation. `ALL_JOBS` currently registers twelve jobs (some are full implementations, some stubs pending future RFCs).
 
-Despite the name "scheduled," there is **no built-in cron or daemon scheduler**. Jobs run in two ways: (1) an opportunistic in-process pass triggered during retrieve/ingest, gated by a cooldown (`opportunistic_cooldown`, default 3600s) and a per-pass time budget (`opportunistic_budget_ms`, default 200ms); and (2) explicit invocation via `prme organize` (optionally `--jobs` and `--budget-ms`). Continuous scheduling, if needed, must be driven by an external cron/timer calling `prme organize`.
+Despite the name "scheduled," there is **no built-in cron or daemon scheduler**. Jobs run in two ways: (1) an opportunistic in-process pass triggered during retrieve/ingest, gated by a cooldown (`opportunistic_cooldown`, default 3600s) and a per-pass time budget (`opportunistic_budget_ms`, default 200ms); and (2) explicit invocation via `prme organize` (optionally `--user-id`, `--jobs`, and `--budget-ms`). Continuous scheduling, if needed, must be driven by an external cron/timer calling `prme organize`.
+
+**Multi-tenant stores must pass a user scope.** `organize(user_id=...)` confines every job to that user's nodes. An unscoped run is correct for a single-tenant store and is still the default, but `deduplicate`, `alias_resolve`, and `consolidate` compare nodes to each other, so a shared store should be maintained as a loop over tenants. `feedback_apply` is the exception: scoring weights are engine-global, so it ignores the scope and reports `"scope": "global"`.
 
 ## RFCs
 

--- a/src/prme/cli.py
+++ b/src/prme/cli.py
@@ -467,6 +467,7 @@ async def cmd_organize(args: argparse.Namespace) -> None:
     try:
         jobs = args.jobs.split(",") if args.jobs else None
         result = await engine.organize(
+            user_id=getattr(args, "user_id", None),
             jobs=jobs,
             budget_ms=args.budget_ms,
         )
@@ -854,6 +855,13 @@ def build_parser() -> argparse.ArgumentParser:
     # organize
     p_organize = subparsers.add_parser("organize", help="Run the organizer")
     add_common(p_organize)
+    p_organize.add_argument(
+        "--user-id",
+        help=(
+            "Scope every job to one user. Multi-tenant stores should run "
+            "once per tenant; an unscoped run merges across tenants"
+        ),
+    )
     p_organize.add_argument(
         "--jobs",
         help="Comma-separated list of jobs to run (e.g. promote,archive)",

--- a/src/prme/organizer/alias_resolution.py
+++ b/src/prme/organizer/alias_resolution.py
@@ -148,6 +148,7 @@ async def find_aliases(
     config: OrganizerConfig,
     batch_size: int = 100,
     budget_ms: float = 5000.0,
+    user_id: str | None = None,
 ) -> list[AliasCandidate]:
     """Find alias relationships between entity nodes.
 
@@ -163,15 +164,17 @@ async def find_aliases(
         config: OrganizerConfig with alias_similarity_threshold.
         batch_size: Max entity nodes to scan per call.
         budget_ms: Time budget in milliseconds.
+        user_id: When given, only this user's entities are scanned.
 
     Returns:
-        List of AliasCandidate pairs.
+        List of AliasCandidate pairs, never spanning two users.
     """
     start = time.monotonic()
     threshold = config.alias_similarity_threshold
 
     # Fetch active entity nodes
     entities = await engine.query_nodes(
+        user_id=user_id,
         node_type=NodeType.ENTITY,
         lifecycle_states=[LifecycleState.TENTATIVE, LifecycleState.STABLE],
         limit=batch_size,
@@ -187,6 +190,11 @@ async def find_aliases(
             return candidates
 
         for j in range(i + 1, len(entities)):
+            # An unscoped run sees every tenant's entities; two tenants both
+            # holding "PostgreSQL" and "postgres" must not be paired (#66).
+            if entities[i].user_id != entities[j].user_id:
+                continue
+
             a_id = str(entities[i].id)
             b_id = str(entities[j].id)
             pair_key = (min(a_id, b_id), max(a_id, b_id))
@@ -242,8 +250,8 @@ async def find_aliases(
             if pair_key in seen_pairs:
                 continue
 
-            # Verify the other node is also an ENTITY
-            other_node = await engine.get_node(other_id)
+            # Verify the other node is also an ENTITY owned by the same user
+            other_node = await engine.get_node(other_id, user_id=entity.user_id)
             if other_node is None or other_node.node_type != NodeType.ENTITY:
                 continue
 
@@ -293,6 +301,15 @@ async def resolve_aliases(
         node_b = await engine.get_node(alias.entity_b_id)
 
         if node_a is None or node_b is None:
+            continue
+
+        # Never merge or link across owners (issue #66).
+        if node_a.user_id != node_b.user_id:
+            logger.warning(
+                "Refusing to resolve cross-user alias pair (%s, %s)",
+                alias.entity_a_id,
+                alias.entity_b_id,
+            )
             continue
 
         if node_a.lifecycle_state not in (LifecycleState.TENTATIVE, LifecycleState.STABLE):

--- a/src/prme/organizer/consolidation.py
+++ b/src/prme/organizer/consolidation.py
@@ -63,6 +63,7 @@ class MemoryCluster:
 async def cluster_similar_memories(
     engine: MemoryEngine,
     *,
+    user_id: str | None = None,
     min_cluster_size: int = 3,
     similarity_threshold: float = 0.80,
 ) -> list[MemoryCluster]:
@@ -75,11 +76,12 @@ async def cluster_similar_memories(
 
     Args:
         engine: The MemoryEngine for storage operations.
+        user_id: When given, only this user's memories are clustered.
         min_cluster_size: Minimum members to form a valid cluster.
         similarity_threshold: Minimum cosine similarity to include in cluster.
 
     Returns:
-        List of MemoryCluster objects.
+        List of MemoryCluster objects, each with a single owner.
     """
     # Fetch active episodic nodes
     episodic_types = [NodeType.FACT, NodeType.EVENT, NodeType.NOTE]
@@ -88,6 +90,7 @@ async def cluster_similar_memories(
     all_nodes: list[MemoryNode] = []
     for ntype in episodic_types:
         nodes = await engine.query_nodes(
+            user_id=user_id,
             node_type=ntype,
             lifecycle_states=active_states,
             limit=500,
@@ -131,6 +134,10 @@ async def cluster_similar_memories(
             if rid in assigned:
                 continue
             if rid not in node_map:
+                continue
+            # A cluster becomes one summary node with one owner, so members
+            # from another tenant would leak content into it (issue #66).
+            if node_map[rid].user_id != node.user_id:
                 continue
             if score < similarity_threshold:
                 continue
@@ -201,6 +208,21 @@ async def consolidate_cluster(
     if not members:
         raise ValueError("No valid member nodes found for consolidation")
 
+    # A summary carries one user_id, so drop any member that does not share
+    # the centroid's owner rather than folding its content in (issue #66).
+    owner = next(
+        (m.user_id for m in members if str(m.id) == cluster.centroid_id),
+        members[0].user_id,
+    )
+    foreign = [m for m in members if m.user_id != owner]
+    if foreign:
+        logger.warning(
+            "Dropping %d cross-user member(s) from cluster centroid=%s",
+            len(foreign),
+            cluster.centroid_id,
+        )
+        members = [m for m in members if m.user_id == owner]
+
     # Extractive summary: pick the highest-confidence content
     # and combine unique content from top members
     sorted_members = sorted(members, key=lambda n: n.confidence, reverse=True)
@@ -228,8 +250,7 @@ async def consolidate_cluster(
     max_salience = max(m.salience for m in members)
     evidence_refs = [m.id for m in members]
 
-    # Determine user_id from first member
-    user_id = members[0].user_id
+    user_id = owner
 
     # Store the summary node via engine.store()
     event_id = await engine.store(
@@ -284,6 +305,7 @@ async def forget_consolidated(
     cluster: MemoryCluster,
     summary_node_id: str,
     *,
+    user_id: str | None = None,
     preserve_recent_days: int = 7,
     min_confidence_preserve: float = 0.8,
 ) -> int:
@@ -299,6 +321,8 @@ async def forget_consolidated(
         engine: The MemoryEngine for storage operations.
         cluster: The cluster whose members to consider for archival.
         summary_node_id: ID of the summary node that supersedes members.
+        user_id: Owner of the summary; members belonging to anyone else are
+            left alone.
         preserve_recent_days: Don't archive memories newer than this.
         min_confidence_preserve: Don't archive memories with confidence >= this.
 
@@ -310,7 +334,9 @@ async def forget_consolidated(
     archived_count = 0
 
     for mid in cluster.member_ids:
-        node = await engine.get_node(mid, include_superseded=False)
+        node = await engine.get_node(
+            mid, include_superseded=False, user_id=user_id
+        )
         if node is None:
             continue
 
@@ -332,7 +358,7 @@ async def forget_consolidated(
 
         # Archive via supersede (marks superseded_by and transitions state)
         try:
-            await engine.supersede(mid, summary_node_id)
+            await engine.supersede(mid, summary_node_id, user_id=user_id)
             archived_count += 1
         except ValueError:
             # Node may already be in a terminal state
@@ -340,7 +366,7 @@ async def forget_consolidated(
                 "Could not supersede node %s, attempting direct archive", mid
             )
             try:
-                await engine.archive(mid)
+                await engine.archive(mid, user_id=user_id)
                 archived_count += 1
             except ValueError:
                 logger.debug("Could not archive node %s, skipping", mid)
@@ -352,6 +378,7 @@ async def run_consolidation_pipeline(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> ConsolidationResult:
     """Run the full consolidation pipeline: cluster, consolidate, forget.
 
@@ -362,6 +389,7 @@ async def run_consolidation_pipeline(
         engine: The MemoryEngine for storage operations.
         config: OrganizerConfig with consolidation parameters.
         budget_ms: Time budget in milliseconds.
+        user_id: When given, only this user's memories are consolidated.
 
     Returns:
         ConsolidationResult with pipeline statistics.
@@ -372,6 +400,7 @@ async def run_consolidation_pipeline(
     # Stage 1: Cluster similar memories
     clusters = await cluster_similar_memories(
         engine,
+        user_id=user_id,
         min_cluster_size=config.consolidation_min_cluster_size,
         similarity_threshold=config.consolidation_similarity_threshold,
     )
@@ -407,6 +436,7 @@ async def run_consolidation_pipeline(
                 engine,
                 cluster,
                 str(summary_node.id),
+                user_id=summary_node.user_id,
                 preserve_recent_days=config.consolidation_preserve_recent_days,
                 min_confidence_preserve=config.consolidation_min_confidence_preserve,
             )

--- a/src/prme/organizer/deduplication.py
+++ b/src/prme/organizer/deduplication.py
@@ -62,6 +62,7 @@ async def find_duplicates(
     config: OrganizerConfig,
     batch_size: int = 100,
     budget_ms: float = 5000.0,
+    user_id: str | None = None,
 ) -> list[DuplicateCandidate]:
     """Find duplicate nodes via vector similarity and exact content match.
 
@@ -74,15 +75,17 @@ async def find_duplicates(
         config: OrganizerConfig with dedup_similarity_threshold.
         batch_size: Max nodes to scan per call.
         budget_ms: Time budget in milliseconds.
+        user_id: When given, only this user's nodes are scanned.
 
     Returns:
-        List of DuplicateCandidate pairs.
+        List of DuplicateCandidate pairs, never spanning two users.
     """
     start = time.monotonic()
     threshold = config.dedup_similarity_threshold
 
     # Fetch active nodes
     nodes = await engine.query_nodes(
+        user_id=user_id,
         lifecycle_states=[LifecycleState.TENTATIVE, LifecycleState.STABLE],
         limit=batch_size,
     )
@@ -91,10 +94,12 @@ async def find_duplicates(
     seen_pairs: set[tuple[str, str]] = set()
     candidates: list[DuplicateCandidate] = []
 
-    # Index by normalized content for exact matching
-    content_groups: dict[str, list[MemoryNode]] = {}
+    # Index by owner plus normalized content for exact matching. The owner is
+    # part of the key so that two tenants storing the same string -- likely
+    # for short or templated content -- are never paired (issue #66).
+    content_groups: dict[tuple[str, str], list[MemoryNode]] = {}
     for node in nodes:
-        key = node.content.strip().lower()
+        key = (node.user_id, node.content.strip().lower())
         content_groups.setdefault(key, []).append(node)
 
     # Phase 1: Exact content matches
@@ -230,6 +235,15 @@ async def merge_duplicates(
 
         if node_a is None or node_b is None:
             # One was already archived/superseded
+            continue
+
+        # Never merge across owners, whatever produced the pair (issue #66).
+        if node_a.user_id != node_b.user_id:
+            logger.warning(
+                "Refusing to merge cross-user duplicate pair (%s, %s)",
+                dup.node_a_id,
+                dup.node_b_id,
+            )
             continue
 
         # Skip if either is not in a mergeable state

--- a/src/prme/organizer/jobs.py
+++ b/src/prme/organizer/jobs.py
@@ -658,7 +658,7 @@ async def _job_tombstone_sweep(
 
         # Archive the expired node
         try:
-            await engine.archive(str(node.id))
+            await engine.archive(str(node.id), user_id=user_id)
             modified += 1
 
             # Log a TOMBSTONE_SWEEP operation via write queue
@@ -675,14 +675,27 @@ async def _job_tombstone_sweep(
                 })
                 conn = getattr(engine, "_conn", None)
                 if conn is not None:
+                    # The write queue awaits what the factory returns, so the
+                    # insert has to be wrapped rather than handed over as a
+                    # bare conn.execute() (which returns a connection).
+                    async def _log(
+                        c=conn,
+                        oid=op_id,
+                        nid=str(node.id),
+                        aid=node.user_id,
+                        p=payload,
+                        n=now,
+                    ) -> None:
+                        await asyncio.to_thread(
+                            c.execute,
+                            "INSERT INTO operations "
+                            "(id, op_type, target_id, actor_id, payload, created_at) "
+                            "VALUES (?, 'TOMBSTONE_SWEEP', ?, ?, ?::JSON, ?)",
+                            [oid, nid, aid, p, n],
+                        )
+
                     await engine._write_queue.submit(
-                        lambda c=conn, oid=op_id, nid=str(node.id), p=payload, n=now: (
-                            c.execute(
-                                "INSERT INTO operations (id, op_type, target_id, payload, created_at) "
-                                "VALUES (?, 'TOMBSTONE_SWEEP', ?, ?::JSON, ?)",
-                                [oid, nid, p, n],
-                            )
-                        ),
+                        _log,
                         label=f"tombstone_sweep.log:{node.id}",
                     )
             except Exception:

--- a/src/prme/organizer/jobs.py
+++ b/src/prme/organizer/jobs.py
@@ -46,6 +46,7 @@ async def run_job(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Dispatch to the appropriate job function.
 
@@ -54,6 +55,11 @@ async def run_job(
         engine: The MemoryEngine for storage operations.
         config: OrganizerConfig with threshold parameters.
         budget_ms: Time budget for this job in milliseconds.
+        user_id: When given, the job only reads and mutates nodes owned by
+            this user. Omitting it keeps the single-tenant behaviour of
+            operating over every node in the store. Multi-tenant deployments
+            must pass it: several jobs merge node pairs, and an unscoped run
+            can pair nodes belonging to different tenants (issue #66).
 
     Returns:
         JobResult with execution details.
@@ -80,7 +86,7 @@ async def run_job(
     if handler is None:
         raise ValueError(f"Unknown organizer job: {job_name!r}")
 
-    return await handler(job_name, engine, config, budget_ms)
+    return await handler(job_name, engine, config, budget_ms, user_id)
 
 
 async def _job_promote(
@@ -88,6 +94,7 @@ async def _job_promote(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Promote eligible tentative nodes to stable.
 
@@ -103,6 +110,7 @@ async def _job_promote(
     cutoff = now - timedelta(days=config.promotion_age_days)
 
     tentative_nodes = await engine.query_nodes(
+        user_id=user_id,
         lifecycle_states=[LifecycleState.TENTATIVE],
         created_before=cutoff,
         oldest_first=True,
@@ -122,7 +130,7 @@ async def _job_promote(
         if len(node.evidence_refs) >= config.promotion_evidence_count:
             processed += 1
             try:
-                await engine.promote(str(node.id))
+                await engine.promote(str(node.id), user_id=user_id)
                 modified += 1
             except ValueError:
                 errors += 1
@@ -142,6 +150,7 @@ async def _job_decay_sweep(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Evaluate all active nodes for threshold transitions based on virtual decay.
 
@@ -159,6 +168,7 @@ async def _job_decay_sweep(
         LifecycleState.CONTESTED,
     ]
     nodes = await engine.query_nodes(
+        user_id=user_id,
         lifecycle_states=active_states,
         limit=500,
     )
@@ -209,7 +219,7 @@ async def _job_decay_sweep(
         # Force archive: very low salience
         if eff_salience < config.force_archive_salience_threshold:
             try:
-                await engine.archive(str(node.id))
+                await engine.archive(str(node.id), user_id=user_id)
                 modified += 1
             except ValueError:
                 errors += 1
@@ -221,11 +231,11 @@ async def _job_decay_sweep(
                 if node.lifecycle_state == LifecycleState.CONTESTED:
                     await engine._graph_store.deprecate(str(node.id))
                 else:
-                    await engine.archive(str(node.id))
+                    await engine.archive(str(node.id), user_id=user_id)
                 modified += 1
             except (ValueError, AttributeError):
                 try:
-                    await engine.archive(str(node.id))
+                    await engine.archive(str(node.id), user_id=user_id)
                     modified += 1
                 except ValueError:
                     errors += 1
@@ -237,7 +247,7 @@ async def _job_decay_sweep(
             and eff_confidence < config.archive_confidence_threshold
         ):
             try:
-                await engine.archive(str(node.id))
+                await engine.archive(str(node.id), user_id=user_id)
                 modified += 1
             except ValueError:
                 errors += 1
@@ -257,6 +267,7 @@ async def _job_archive(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Archive nodes below force_archive_salience_threshold.
 
@@ -272,6 +283,7 @@ async def _job_archive(
         LifecycleState.CONTESTED,
     ]
     nodes = await engine.query_nodes(
+        user_id=user_id,
         lifecycle_states=active_states,
         limit=500,
     )
@@ -308,7 +320,7 @@ async def _job_archive(
 
         if eff_salience < config.force_archive_salience_threshold:
             try:
-                await engine.archive(str(node.id))
+                await engine.archive(str(node.id), user_id=user_id)
                 modified += 1
             except ValueError:
                 errors += 1
@@ -328,6 +340,7 @@ async def _job_feedback_apply(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Apply user feedback signals to auto-tune retrieval scoring weights.
 
@@ -338,6 +351,12 @@ async def _job_feedback_apply(
 
     This implements the feedback loop described in RFC-0009, extended by
     issue #24 with gradient-free weight auto-tuning.
+
+    ``user_id`` is accepted but cannot be honoured: the feedback tracker and
+    the scoring weights are both engine-global and FeedbackSignal carries no
+    user, so there is no per-tenant slice to apply. A scoped run still tunes
+    weights for everyone. Per-tenant tuning needs a user dimension on the
+    signal itself (issue #66).
     """
     start = time.monotonic()
 
@@ -348,6 +367,13 @@ async def _job_feedback_apply(
         return JobResult(
             job=job_name,
             details={"status": "no_signals", "note": "No pending feedback signals"},
+        )
+
+    if user_id is not None:
+        logger.warning(
+            "feedback_apply ignores its %r scope: scoring weights are "
+            "engine-global and apply to every user",
+            user_id,
         )
 
     # Run weight tuner
@@ -389,6 +415,7 @@ async def _job_feedback_apply(
             "old_weight_version": old_version,
             "new_weight_version": new_version,
             "weights_changed": old_version != new_version,
+            "scope": "global",
         },
     )
 
@@ -398,6 +425,7 @@ async def _job_deduplicate(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Find and merge duplicate memory nodes (issue #11).
 
@@ -411,7 +439,7 @@ async def _job_deduplicate(
 
     try:
         duplicates = await find_duplicates(
-            engine, config, budget_ms=budget_ms / 2,
+            engine, config, budget_ms=budget_ms / 2, user_id=user_id,
         )
         merged_count = await merge_duplicates(engine, duplicates)
     except Exception:
@@ -441,6 +469,7 @@ async def _job_alias_resolve(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Find and resolve entity alias relationships (issue #11).
 
@@ -454,7 +483,7 @@ async def _job_alias_resolve(
 
     try:
         aliases = await find_aliases(
-            engine, config, budget_ms=budget_ms / 2,
+            engine, config, budget_ms=budget_ms / 2, user_id=user_id,
         )
         resolved_count = await resolve_aliases(engine, aliases)
     except Exception:
@@ -484,6 +513,7 @@ async def _job_snapshot_generation(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Generate snapshots for active entity nodes.
 
@@ -498,6 +528,7 @@ async def _job_snapshot_generation(
     start = time.monotonic()
 
     entities = await engine.query_nodes(
+        user_id=user_id,
         node_type=NodeType.ENTITY,
         lifecycle_states=[LifecycleState.TENTATIVE, LifecycleState.STABLE],
         limit=500,
@@ -535,6 +566,7 @@ async def _job_consolidate(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Run the predictive forgetting / consolidation pipeline (issue #22).
 
@@ -547,7 +579,7 @@ async def _job_consolidate(
     start = time.monotonic()
 
     consolidation_result = await run_consolidation_pipeline(
-        engine, config, budget_ms
+        engine, config, budget_ms, user_id=user_id
     )
 
     duration_ms = (time.monotonic() - start) * 1000.0
@@ -571,6 +603,7 @@ async def _job_tombstone_sweep(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Archive nodes that have exceeded their TTL (issue #12, RFC-0007 S9).
 
@@ -593,6 +626,7 @@ async def _job_tombstone_sweep(
         LifecycleState.CONTESTED,
     ]
     nodes = await engine.query_nodes(
+        user_id=user_id,
         lifecycle_states=active_states,
         limit=500,
     )
@@ -676,6 +710,7 @@ async def _job_summarize(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Run hierarchical summarization: daily -> weekly -> monthly.
 
@@ -699,7 +734,9 @@ async def _job_summarize(
     monthly_budget = budget_ms * 0.2
 
     try:
-        daily_result = await generate_daily_summaries(engine, config, daily_budget)
+        daily_result = await generate_daily_summaries(
+            engine, config, daily_budget, user_id
+        )
         total_processed += daily_result.nodes_processed
         total_modified += daily_result.nodes_modified
         total_errors += daily_result.errors
@@ -709,7 +746,7 @@ async def _job_summarize(
         total_errors += 1
 
     try:
-        weekly_result = await roll_up_weekly(engine, config, weekly_budget)
+        weekly_result = await roll_up_weekly(engine, config, weekly_budget, user_id)
         total_processed += weekly_result.nodes_processed
         total_modified += weekly_result.nodes_modified
         total_errors += weekly_result.errors
@@ -719,7 +756,7 @@ async def _job_summarize(
         total_errors += 1
 
     try:
-        monthly_result = await roll_up_monthly(engine, config, monthly_budget)
+        monthly_result = await roll_up_monthly(engine, config, monthly_budget, user_id)
         total_processed += monthly_result.nodes_processed
         total_modified += monthly_result.nodes_modified
         total_errors += monthly_result.errors
@@ -744,6 +781,7 @@ async def _job_index_compaction(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Reconcile the vector/lexical indexes against active graph nodes (#41).
 
@@ -757,6 +795,10 @@ async def _job_index_compaction(
     The vector_metadata table is the reconciliation anchor because every
     indexed node has a row there; the matching lexical doc is evicted by
     node_id at the same time.
+
+    Under a user scope only that user's stale entries are evicted. Rows whose
+    node has vanished from the graph entirely can no longer be attributed to
+    a user, so they are left for an unscoped run to collect.
     """
     start = time.monotonic()
 
@@ -779,6 +821,18 @@ async def _job_index_compaction(
         # Node either missing from the graph (LEFT JOIN NULL) or in a
         # non-active lifecycle state. DISTINCT so a node with several
         # vectors is evicted once.
+        if user_id is not None:
+            # An orphaned row has no owner to compare against, so a scoped
+            # run can only reach nodes that still exist.
+            rows = conn.execute(
+                "SELECT DISTINCT vm.node_id FROM vector_metadata vm "
+                "JOIN nodes n ON vm.node_id = n.id "
+                "WHERE n.user_id = ? "
+                f"AND n.lifecycle_state NOT IN ({placeholders})",
+                [user_id, *active],
+            ).fetchall()
+            return [row[0] for row in rows]
+
         rows = conn.execute(
             "SELECT DISTINCT vm.node_id FROM vector_metadata vm "
             "LEFT JOIN nodes n ON vm.node_id = n.id "
@@ -825,6 +879,7 @@ async def _job_stub(
     engine: MemoryEngine,
     config: OrganizerConfig,
     budget_ms: float,
+    user_id: str | None = None,
 ) -> JobResult:
     """Stub job returning an empty result.
 

--- a/src/prme/organizer/maintenance.py
+++ b/src/prme/organizer/maintenance.py
@@ -8,6 +8,14 @@ The MaintenanceRunner checks a cooldown timer and, if sufficient time
 has elapsed since the last pass, runs a bounded maintenance cycle:
 auto-promotion of eligible tentative nodes and threshold-based archival
 of decayed nodes.
+
+The pass is deliberately store-wide rather than per-tenant. It has no
+request to take an identity from, and both of its tasks are per-node
+lifecycle transitions driven by that node's own age and decay: neither
+reads one node to decide something about another, so there is nothing to
+leak between tenants. The jobs that do compare nodes to each other
+(deduplicate, alias_resolve, consolidate) are Layer 3 only, and those take
+a user scope from ``organize()`` (issue #66).
 """
 
 from __future__ import annotations

--- a/src/prme/storage/engine.py
+++ b/src/prme/storage/engine.py
@@ -1865,7 +1865,12 @@ class MemoryEngine:
         Stops early if the total budget is exceeded.
 
         Args:
-            user_id: Optional user scope for organization.
+            user_id: When given, every job only reads and mutates nodes owned
+                by this user. Multi-tenant deployments must pass it and drive
+                maintenance as a loop over tenants: an unscoped run merges
+                duplicate and alias pairs across tenant boundaries. Omitting
+                it keeps the single-tenant behaviour of covering the whole
+                store.
             jobs: List of job names to run. Defaults to ALL_JOBS.
             budget_ms: Total time budget in milliseconds.
 
@@ -1906,7 +1911,7 @@ class MemoryEngine:
 
             try:
                 job_result = await run_job(
-                    job_name, self, self._config.organizer, remaining_ms
+                    job_name, self, self._config.organizer, remaining_ms, user_id
                 )
                 result.jobs_run.append(job_name)
                 result.per_job[job_name] = job_result

--- a/tests/test_organizer_tenancy.py
+++ b/tests/test_organizer_tenancy.py
@@ -1,0 +1,251 @@
+"""Tests for organizer tenant scoping (issue #66).
+
+Two separate guarantees:
+
+1. ``organize(user_id=...)`` reaches the jobs. It used to be accepted,
+   documented, and then dropped on the floor, so a caller could scope a run,
+   get a success response, and have every job touch every tenant.
+2. The merging jobs never pair nodes owned by different users, even on an
+   unscoped run. Exact-content dedup and string-based alias matching both
+   compare content across the whole batch, so two tenants storing the same
+   short or templated string used to become a "duplicate" pair, and merging
+   archives one of them.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from prme.config import OrganizerConfig, PRMEConfig
+from prme.organizer.alias_resolution import (
+    AliasCandidate,
+    find_aliases,
+    resolve_aliases,
+)
+from prme.organizer.deduplication import (
+    DuplicateCandidate,
+    find_duplicates,
+    merge_duplicates,
+)
+from prme.organizer.jobs import run_job
+from prme.storage.engine import MemoryEngine
+from prme.types import LifecycleState, NodeType
+
+ACTIVE = (LifecycleState.TENTATIVE, LifecycleState.STABLE)
+
+
+@pytest_asyncio.fixture
+async def engine():
+    with tempfile.TemporaryDirectory(prefix="prme_tenancy_") as d:
+        tmp = Path(d)
+        lexical_path = tmp / "lexical_index"
+        lexical_path.mkdir()
+        eng = await MemoryEngine.create(PRMEConfig(
+            db_path=str(tmp / "memory.duckdb"),
+            vector_path=str(tmp / "vectors.usearch"),
+            lexical_path=str(lexical_path),
+        ))
+        yield eng
+        await eng.close()
+
+
+@pytest.fixture
+def org_config():
+    return OrganizerConfig()
+
+
+async def _nodes_for(engine: MemoryEngine, user_id: str):
+    # query_nodes defaults to active states only; the point of these tests is
+    # what an organizer job did to a node, so ask for every state.
+    return await engine.query_nodes(
+        user_id=user_id, lifecycle_states=list(LifecycleState)
+    )
+
+
+async def _states_for(engine: MemoryEngine, user_id: str) -> list[LifecycleState]:
+    return [n.lifecycle_state for n in await _nodes_for(engine, user_id)]
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant merging
+# ---------------------------------------------------------------------------
+
+
+async def test_identical_content_across_users_is_not_a_duplicate(
+    engine, org_config
+):
+    # Short, templated content is what makes this collide in practice.
+    for user in ("alice", "bob"):
+        await engine.store("ok", user_id=user, node_type=NodeType.FACT)
+
+    duplicates = await find_duplicates(engine, org_config)
+
+    owners = {}
+    for node in await engine.query_nodes():
+        owners[str(node.id)] = node.user_id
+    for dup in duplicates:
+        assert owners[dup.node_a_id] == owners[dup.node_b_id], (
+            f"cross-user duplicate pair: {dup!r}"
+        )
+
+
+async def test_deduplicate_job_leaves_both_tenants_intact(engine, org_config):
+    for user in ("alice", "bob"):
+        await engine.store("ok", user_id=user, node_type=NodeType.FACT)
+
+    await run_job("deduplicate", engine, org_config, 5000.0)
+
+    for user in ("alice", "bob"):
+        states = await _states_for(engine, user)
+        assert states == [LifecycleState.TENTATIVE], f"{user} was mutated: {states}"
+
+
+async def test_duplicates_within_one_tenant_are_still_found(engine, org_config):
+    await engine.store("ok", user_id="alice", node_type=NodeType.FACT)
+    await engine.store("ok", user_id="alice", node_type=NodeType.FACT)
+    await engine.store("ok", user_id="bob", node_type=NodeType.FACT)
+
+    duplicates = await find_duplicates(engine, org_config)
+    exact = [d for d in duplicates if d.match_type == "exact"]
+    assert len(exact) == 1
+
+    alice_ids = {str(n.id) for n in await _nodes_for(engine, "alice")}
+    assert {exact[0].node_a_id, exact[0].node_b_id} <= alice_ids
+
+
+async def test_merge_duplicates_refuses_a_cross_user_pair(engine):
+    await engine.store("ok", user_id="alice", node_type=NodeType.FACT)
+    await engine.store("ok", user_id="bob", node_type=NodeType.FACT)
+
+    alice_id = str((await _nodes_for(engine, "alice"))[0].id)
+    bob_id = str((await _nodes_for(engine, "bob"))[0].id)
+
+    merged = await merge_duplicates(
+        engine, [DuplicateCandidate(alice_id, bob_id, 1.0, "exact")]
+    )
+
+    assert merged == 0
+    for node_id in (alice_id, bob_id):
+        node = await engine.get_node(node_id, include_superseded=True)
+        assert node.lifecycle_state in ACTIVE
+
+
+async def test_aliases_are_not_matched_across_users(engine, org_config):
+    # "PostgreSQL" and "postgres" are a known alias pair, so this only stays
+    # unmatched if ownership is checked.
+    await engine.store("PostgreSQL", user_id="alice", node_type=NodeType.ENTITY)
+    await engine.store("postgres", user_id="bob", node_type=NodeType.ENTITY)
+
+    aliases = await find_aliases(engine, org_config)
+
+    assert aliases == []
+
+
+async def test_alias_resolve_job_leaves_both_tenants_intact(engine, org_config):
+    await engine.store("PostgreSQL", user_id="alice", node_type=NodeType.ENTITY)
+    await engine.store("postgres", user_id="bob", node_type=NodeType.ENTITY)
+
+    await run_job("alias_resolve", engine, org_config, 5000.0)
+
+    for user in ("alice", "bob"):
+        states = await _states_for(engine, user)
+        assert states == [LifecycleState.TENTATIVE], f"{user} was mutated: {states}"
+
+
+async def test_resolve_aliases_refuses_a_cross_user_pair(engine):
+    await engine.store("PostgreSQL", user_id="alice", node_type=NodeType.ENTITY)
+    await engine.store("postgres", user_id="bob", node_type=NodeType.ENTITY)
+
+    alice_id = str((await _nodes_for(engine, "alice"))[0].id)
+    bob_id = str((await _nodes_for(engine, "bob"))[0].id)
+
+    resolved = await resolve_aliases(
+        engine, [AliasCandidate(alice_id, bob_id, "abbreviation", 0.95)]
+    )
+
+    assert resolved == 0
+    for node_id in (alice_id, bob_id):
+        node = await engine.get_node(node_id, include_superseded=True)
+        assert node.lifecycle_state in ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# organize(user_id=...) reaches the jobs
+# ---------------------------------------------------------------------------
+
+
+async def test_organize_user_scope_confines_tombstone_sweep(engine):
+    # ttl_days=0 expires the node the moment it is created, so the sweep is
+    # eligible to archive both of these.
+    for user in ("alice", "bob"):
+        await engine.store(
+            f"{user} ephemeral note", user_id=user, node_type=NodeType.NOTE,
+            ttl_days=0,
+        )
+
+    result = await engine.organize(
+        user_id="alice", jobs=["tombstone_sweep"], budget_ms=5000
+    )
+
+    assert result.per_job["tombstone_sweep"].nodes_modified == 1
+    assert await _states_for(engine, "alice") == [LifecycleState.ARCHIVED]
+    assert await _states_for(engine, "bob") == [LifecycleState.TENTATIVE]
+
+
+async def test_organize_user_scope_confines_deduplicate(engine):
+    for user in ("alice", "bob"):
+        await engine.store("shared note", user_id=user, node_type=NodeType.FACT)
+        await engine.store("shared note", user_id=user, node_type=NodeType.FACT)
+
+    await engine.organize(user_id="alice", jobs=["deduplicate"], budget_ms=5000)
+
+    alice_states = sorted(s.value for s in await _states_for(engine, "alice"))
+    assert alice_states == ["superseded", "tentative"]
+    assert await _states_for(engine, "bob") == [
+        LifecycleState.TENTATIVE,
+        LifecycleState.TENTATIVE,
+    ]
+
+
+async def test_unscoped_organize_still_covers_every_user(engine):
+    for user in ("alice", "bob"):
+        await engine.store(
+            f"{user} ephemeral note", user_id=user, node_type=NodeType.NOTE,
+            ttl_days=0,
+        )
+
+    await engine.organize(jobs=["tombstone_sweep"], budget_ms=5000)
+
+    for user in ("alice", "bob"):
+        assert await _states_for(engine, user) == [LifecycleState.ARCHIVED]
+
+
+async def test_feedback_apply_reports_that_it_cannot_be_scoped(engine, org_config):
+    # Scoring weights are engine-global, so this job is the one exception to
+    # per-tenant organization. It says so rather than implying otherwise.
+    from prme.quality.feedback import FeedbackSignal, FeedbackSignalType
+
+    for _ in range(10):
+        await engine.feedback(FeedbackSignal(
+            query="what did I say",
+            surfaced_node_ids=[],
+            signal_type=FeedbackSignalType.CORRECTED,
+        ))
+
+    result = await run_job("feedback_apply", engine, org_config, 5000.0, "alice")
+
+    assert result.details["scope"] == "global"
+
+
+async def test_every_job_accepts_a_user_scope(engine, org_config):
+    from prme.organizer.jobs import ALL_JOBS
+
+    await engine.store("alice note", user_id="alice", node_type=NodeType.FACT)
+
+    for job_name in ALL_JOBS:
+        result = await run_job(job_name, engine, org_config, 500.0, "alice")
+        assert result.errors == 0, f"{job_name} errored under a user scope"

--- a/tests/test_organizer_tenancy.py
+++ b/tests/test_organizer_tenancy.py
@@ -196,6 +196,25 @@ async def test_organize_user_scope_confines_tombstone_sweep(engine):
     assert await _states_for(engine, "bob") == [LifecycleState.TENTATIVE]
 
 
+async def test_tombstone_sweep_logs_the_operation_with_its_actor(engine):
+    # The insert used to be handed to the write queue as a bare
+    # conn.execute(), which is not awaitable, so every log silently failed
+    # and the operations table stayed empty.
+    await engine.store(
+        "alice ephemeral note", user_id="alice", node_type=NodeType.NOTE,
+        ttl_days=0,
+    )
+
+    await engine.organize(
+        user_id="alice", jobs=["tombstone_sweep"], budget_ms=5000
+    )
+
+    rows = engine._conn.execute(
+        "SELECT actor_id FROM operations WHERE op_type = 'TOMBSTONE_SWEEP'"
+    ).fetchall()
+    assert [r[0] for r in rows] == ["alice"]
+
+
 async def test_organize_user_scope_confines_deduplicate(engine):
     for user in ("alice", "bob"):
         await engine.store("shared note", user_id=user, node_type=NodeType.FACT)


### PR DESCRIPTION
Closes #66. Follows #68, which landed the storage half of the tenant isolation work.

## The inert parameter

`MemoryEngine.organize()` accepted `user_id`, documented it as a user scope, and never passed it on: `run_job()` had no such parameter. `POST /v1/organize` and the MCP `memory_organize` tool exposed the same parameter, so a caller could scope a run, receive a success response, and have every job operate across every tenant.

`user_id` now flows from `organize()` through `run_job()` into every job, and each job's node query is scoped by it.

## The cross-tenant merges

Two jobs did more than read across tenants.

`find_duplicates()` fetched candidates with no user filter and grouped them by normalized content, so two tenants storing the same string became a duplicate pair. Merging that pair archives one node and writes a SUPERSEDES edge between them, which is cross-tenant mutation rather than only a read leak. Short or templated content ("ok", "thanks", a standard onboarding line) makes the collision likely rather than theoretical. The string matching phase of alias resolution had the same shape: "PostgreSQL" under one tenant and "postgres" under another are a known alias pair.

Two layers now guard the merges independently of the scope, so an unscoped single-tenant run is also safe:

- Exact-content dedup keys on `(user_id, content)`.
- Alias string matching skips pairs with different owners, and its vector phase verifies the other node's owner.
- Cluster membership requires the centroid's owner, and `consolidate_cluster()` drops any member that does not share it.
- `merge_duplicates()` and `resolve_aliases()` refuse a pair that crosses users, whatever produced it.

## The two jobs that cannot be scoped

`feedback_apply` tunes engine-global scoring weights from a tracker whose signals carry no user, so there is no per-tenant slice to apply. It logs that it is ignoring the scope and reports `"scope": "global"` rather than implying otherwise. Per-tenant tuning needs a user dimension on `FeedbackSignal` first.

A scoped `index_compaction` skips vector rows whose node has vanished from the graph entirely, since an orphan can no longer be attributed to an owner. An unscoped run still collects them.

The opportunistic maintenance pass stays store-wide. It has no request to take an identity from, and its two tasks are per-node lifecycle transitions driven by each node's own age and decay, so neither reads one node to decide something about another. The reasoning is recorded in its module docstring so it does not read as an oversight.

## Second bug, found while testing

The tombstone sweep handed the write queue a bare `conn.execute()` call. The lambda body runs the insert when the queue invokes it, so the row landed, and then the queue awaited the DuckDB connection that `execute()` returned and raised `TypeError`. Every archived node produced a failed write-queue job and a warning traceback for work that had already succeeded. The insert is now wrapped in a coroutine, runs off the event loop, and fills `actor_id` with the node's owner, which the table already had a column for.

## Tests

`tests/test_organizer_tenancy.py`, 13 tests. Eleven of them fail on `main`. They cover both directions: no job pairs across tenants, and a scoped run leaves other tenants untouched while an unscoped run still covers everyone. One test asserts that duplicates within a single tenant are still found, so the ownership key cannot be "fixed" by disabling dedup.

Full suite: 1260 passing, 25 skipped, up from 1247.

## Operational note

Multi-tenant deployments must drive maintenance as a loop over tenants. `prme organize` gains `--user-id`, and CLAUDE.md records the requirement.
